### PR TITLE
PDI-1486: Update output.go to Log Messages

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pingidentity/pingctl/cmd/platform"
 	"github.com/pingidentity/pingctl/internal/logger"
+	"github.com/pingidentity/pingctl/internal/output"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -36,8 +37,6 @@ var (
 
 // rootCmd represents the base command when called without any subcommands
 func NewRootCommand() *cobra.Command {
-	l := logger.Get()
-
 	cmd := &cobra.Command{
 		Use:     "pingctl",
 		Version: "v0.0.1",
@@ -56,7 +55,10 @@ func NewRootCommand() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&colorizeOutput, colorParamName, true, "Use colorized output")
 
 	if err := bindPersistentFlags(rootConfigurationParamMapping, cmd); err != nil {
-		l.Error().Err(err).Msgf("Error binding flag parameters. Flag values may not be recognized.")
+		output.Format(cmd, output.CommandOutput{
+			Message: "Error binding flag parameters. Flag values may not be recognized.",
+			Error:   err,
+		})
 	}
 
 	return cmd

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -43,7 +43,7 @@ func Get() zerolog.Logger {
 		case "NOLEVEL":
 			logLevel = zerolog.NoLevel
 		default:
-			logLevel = zerolog.ErrorLevel
+			logLevel = zerolog.Disabled
 		}
 
 		var output io.Writer

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -60,25 +60,39 @@ func Format(cmd *cobra.Command, output CommandOutput) {
 }
 
 func formatText(cmd *cobra.Command, output CommandOutput) {
+	l := logger.Get()
+
+	var resultFormat string
+	var resultColor func(format string, a ...interface{}) string
 	switch output.Result {
 	case ENUMCOMMANDOUTPUTRESULT_SUCCESS:
-		cmd.Println(green("%s - %s", output.Message, output.Result))
+		resultFormat = "%s - %s"
+		resultColor = green
 	case ENUMCOMMANDOUTPUTRESULT_NOACTION_OK:
-		cmd.Println(green("%s - %s", output.Message, output.Result))
+		resultFormat = "%s - %s"
+		resultColor = green
 	case ENUMCOMMANDOUTPUTRESULT_NOACTION_WARN:
-		cmd.Println(yellow("%s - %s", output.Message, output.Result))
+		resultFormat = "%s - %s"
+		resultColor = yellow
 	case ENUMCOMMANDOUTPUTRESULT_FAILURE:
-		cmd.Println(red("%s - %s", output.Message, output.Result))
+		resultFormat = "%s - %s"
+		resultColor = red
 	case ENUMCOMMANDOUTPUTRESULT_NIL:
-		cmd.Println(white("%s", output.Message))
+		resultFormat = "%s%s"
+		resultColor = white
 	default:
-		cmd.Println(white("%s", output.Message))
+		resultFormat = "%s%s"
+		resultColor = white
 	}
+
+	cmd.Println(resultColor(resultFormat, output.Message, output.Result))
+	l.Info().Msgf("%s", resultColor(resultFormat, output.Message, output.Result))
 
 	if output.Fields != nil {
 		cmd.Println(cyan("Additional Information:"))
 		for k, v := range output.Fields {
 			cmd.Println(cyan("%s: %s", k, v))
+			l.Info().Msgf("%s", cyan("%s: %s", k, v))
 		}
 	}
 
@@ -94,4 +108,5 @@ func formatJson(cmd *cobra.Command, output CommandOutput) {
 	}
 
 	cmd.Println(string(jsonOut))
+	l.Info().Msgf("%s", string(jsonOut))
 }

--- a/main.go
+++ b/main.go
@@ -2,16 +2,18 @@ package main
 
 import (
 	"github.com/pingidentity/pingctl/cmd"
-	"github.com/pingidentity/pingctl/internal/logger"
+	"github.com/pingidentity/pingctl/internal/output"
 )
 
 func main() {
-	l := logger.Get()
-
 	rootCmd := cmd.NewRootCommand()
 
 	err := rootCmd.Execute()
 	if err != nil {
-		l.Fatal().Err(err).Msgf("Failed to execute pingctl")
+		output.Format(rootCmd, output.CommandOutput{
+			Fatal:   err,
+			Message: "Failed to execute pingctl",
+			Result:  output.ENUMCOMMANDOUTPUTRESULT_FAILURE,
+		})
 	}
 }


### PR DESCRIPTION
- Log output formatter in addition to its stdout output
- Update output formatter to handle errors, fatals, and warnings.
- Update error messages that should be sent to user as 