### PR TITLE
PDI-1516: Add pingone_custom_domain (Resource) Export

### DIFF
--- a/.github/workflows/code-analysis-lint-test.yaml
+++ b/.github/workflows/code-analysis-lint-test.yaml
@@ -127,6 +127,8 @@ jobs:
       PINGCTL_PINGONE_WORKER_CLIENT_SECRET: ${{ secrets.PINGCTL_PINGONE_WORKER_CLIENT_SECRET }}
       PINGCTL_PINGONE_REGION: ${{ secrets.PINGCTL_PINGONE_REGION }}
       PINGCTL_PINGONE_WORKER_ENVIRONMENT_ID: ${{ secrets.PINGCTL_PINGONE_WORKER_ENVIRONMENT_ID }}
+      PINGCTL_LOG_LEVEL: ${{ secrets.PINGCTL_LOG_LEVEL }}
+      PINGCTL_LOG_PATH: ${{ secrets.PINGCTL_LOG_PATH }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/code-analysis-lint-test.yaml
+++ b/.github/workflows/code-analysis-lint-test.yaml
@@ -127,8 +127,8 @@ jobs:
       PINGCTL_PINGONE_WORKER_CLIENT_SECRET: ${{ secrets.PINGCTL_PINGONE_WORKER_CLIENT_SECRET }}
       PINGCTL_PINGONE_REGION: ${{ secrets.PINGCTL_PINGONE_REGION }}
       PINGCTL_PINGONE_WORKER_ENVIRONMENT_ID: ${{ secrets.PINGCTL_PINGONE_WORKER_ENVIRONMENT_ID }}
-      PINGCTL_LOG_LEVEL: ${{ secrets.PINGCTL_LOG_LEVEL }}
-      PINGCTL_LOG_PATH: ${{ secrets.PINGCTL_LOG_PATH }}
+      PINGCTL_LOG_LEVEL: ${{ vars.PINGCTL_LOG_LEVEL }}
+      PINGCTL_LOG_PATH: ${{ vars.PINGCTL_LOG_PATH }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/code-analysis-lint-test.yaml
+++ b/.github/workflows/code-analysis-lint-test.yaml
@@ -76,7 +76,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.

--- a/cmd/auth/auth_test.go
+++ b/cmd/auth/auth_test.go
@@ -44,12 +44,12 @@ func TestAuthLogoutCmd_Execute(t *testing.T) {
 	rootCmd.SetArgs([]string{"auth", "logout"})
 
 	// Execute the command
-	err := rootCmd.Execute()
-	if err != nil {
+	executeErr := rootCmd.Execute()
+	if executeErr != nil {
 		logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
 		if err == nil {
 			t.Logf("Captured Logs: %s", string(logContent[:]))
 		}
-		t.Fatalf("Err: %q, Captured StdOut: %q", err, stdout.String())
+		t.Fatalf("Err: %q, Captured StdOut: %q", executeErr, stdout.String())
 	}
 }

--- a/cmd/auth/auth_test.go
+++ b/cmd/auth/auth_test.go
@@ -21,13 +21,13 @@ func TestAuthLoginCmd_Execute(t *testing.T) {
 	rootCmd.SetArgs([]string{"auth", "login"})
 
 	// Execute the command
-	err := rootCmd.Execute()
-	if err != nil {
+	executeErr := rootCmd.Execute()
+	if executeErr != nil {
 		logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
 		if err == nil {
 			t.Logf("Captured Logs: %s", string(logContent[:]))
 		}
-		t.Fatalf("Err: %q, Captured StdOut: %q", err, stdout.String())
+		t.Fatalf("Err: %q, Captured StdOut: %q", executeErr, stdout.String())
 	}
 }
 

--- a/cmd/auth/auth_test.go
+++ b/cmd/auth/auth_test.go
@@ -2,6 +2,7 @@ package auth_test
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/pingidentity/pingctl/cmd"
@@ -22,6 +23,10 @@ func TestAuthLoginCmd_Execute(t *testing.T) {
 	// Execute the command
 	err := rootCmd.Execute()
 	if err != nil {
+		logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
+		if err == nil {
+			t.Logf("Captured Logs: %s", string(logContent[:]))
+		}
 		t.Fatalf("Err: %q, Captured StdOut: %q", err, stdout.String())
 	}
 }
@@ -41,6 +46,10 @@ func TestAuthLogoutCmd_Execute(t *testing.T) {
 	// Execute the command
 	err := rootCmd.Execute()
 	if err != nil {
+		logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
+		if err == nil {
+			t.Logf("Captured Logs: %s", string(logContent[:]))
+		}
 		t.Fatalf("Err: %q, Captured StdOut: %q", err, stdout.String())
 	}
 }

--- a/cmd/auth/auth_test.go
+++ b/cmd/auth/auth_test.go
@@ -2,10 +2,10 @@ package auth_test
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/pingidentity/pingctl/cmd"
+	"github.com/pingidentity/pingctl/internal/testutils"
 )
 
 // Test Auth Login Command Executes without issue
@@ -21,13 +21,10 @@ func TestAuthLoginCmd_Execute(t *testing.T) {
 	rootCmd.SetArgs([]string{"auth", "login"})
 
 	// Execute the command
-	executeErr := rootCmd.Execute()
-	if executeErr != nil {
-		logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
-		if err == nil {
-			t.Logf("Captured Logs: %s", string(logContent[:]))
-		}
-		t.Fatalf("Err: %q, Captured StdOut: %q", executeErr, stdout.String())
+	err := rootCmd.Execute()
+	if err != nil {
+		testutils.PrintLogs(t)
+		t.Fatalf("Err: %q, Captured StdOut: %q", err, stdout.String())
 	}
 }
 
@@ -44,12 +41,9 @@ func TestAuthLogoutCmd_Execute(t *testing.T) {
 	rootCmd.SetArgs([]string{"auth", "logout"})
 
 	// Execute the command
-	executeErr := rootCmd.Execute()
-	if executeErr != nil {
-		logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
-		if err == nil {
-			t.Logf("Captured Logs: %s", string(logContent[:]))
-		}
-		t.Fatalf("Err: %q, Captured StdOut: %q", executeErr, stdout.String())
+	err := rootCmd.Execute()
+	if err != nil {
+		testutils.PrintLogs(t)
+		t.Fatalf("Err: %q, Captured StdOut: %q", err, stdout.String())
 	}
 }

--- a/cmd/feedback_test.go
+++ b/cmd/feedback_test.go
@@ -2,10 +2,10 @@ package cmd_test
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/pingidentity/pingctl/cmd"
+	"github.com/pingidentity/pingctl/internal/testutils"
 )
 
 // Test Feedback Command Executes without issue
@@ -21,12 +21,9 @@ func TestFeedbackCmd_Execute(t *testing.T) {
 	rootCmd.SetArgs([]string{"feedback"})
 
 	// Execute the root command
-	executeErr := rootCmd.Execute()
-	if executeErr != nil {
-		logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
-		if err == nil {
-			t.Logf("Captured Logs: %s", string(logContent[:]))
-		}
-		t.Fatalf("Err: %q, Captured StdOut: %q", executeErr, stdout.String())
+	err := rootCmd.Execute()
+	if err != nil {
+		testutils.PrintLogs(t)
+		t.Fatalf("Err: %q, Captured StdOut: %q", err, stdout.String())
 	}
 }

--- a/cmd/feedback_test.go
+++ b/cmd/feedback_test.go
@@ -2,6 +2,7 @@ package cmd_test
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/pingidentity/pingctl/cmd"
@@ -22,6 +23,10 @@ func TestFeedbackCmd_Execute(t *testing.T) {
 	// Execute the root command
 	err := rootCmd.Execute()
 	if err != nil {
+		logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
+		if err == nil {
+			t.Logf("Captured Logs: %s", string(logContent[:]))
+		}
 		t.Fatalf("Err: %q, Captured StdOut: %q", err, stdout.String())
 	}
 }

--- a/cmd/feedback_test.go
+++ b/cmd/feedback_test.go
@@ -21,12 +21,12 @@ func TestFeedbackCmd_Execute(t *testing.T) {
 	rootCmd.SetArgs([]string{"feedback"})
 
 	// Execute the root command
-	err := rootCmd.Execute()
-	if err != nil {
+	executeErr := rootCmd.Execute()
+	if executeErr != nil {
 		logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
 		if err == nil {
 			t.Logf("Captured Logs: %s", string(logContent[:]))
 		}
-		t.Fatalf("Err: %q, Captured StdOut: %q", err, stdout.String())
+		t.Fatalf("Err: %q, Captured StdOut: %q", executeErr, stdout.String())
 	}
 }

--- a/cmd/platform/export.go
+++ b/cmd/platform/export.go
@@ -45,6 +45,7 @@ var (
 
 	exportConfigurationParamMapping = map[string]string{
 		pingoneWorkerEnvironmentIdParamName: pingoneWorkerEnvironmentIdParamConfigKey,
+		pingoneExportEnvironmentIdParamName: pingoneExportEnvironmentIdParamConfigKey,
 		pingoneWorkerClientIdParamName:      pingoneWorkerClientIdParamConfigKey,
 		pingoneWorkerClientSecretParamName:  pingoneWorkerClientSecretParamConfigKey,
 		pingoneRegionParamName:              pingoneRegionParamConfigKey,
@@ -62,7 +63,7 @@ func NewExportCommand() *cobra.Command {
 
 			l.Debug().Msgf("Export Subcommand Called.")
 
-			apiClient, err := initApiClient(cmd.Context(), cmd)
+			apiClient, err := initApiClient(cmd.Context())
 			if err != nil {
 				output.Format(cmd, output.CommandOutput{
 					Message: "Unable to initialize PingOne SDK client",
@@ -139,7 +140,7 @@ func NewExportCommand() *cobra.Command {
 
 	// Add flags that are bound to configuration file keys
 	cmd.Flags().String(pingoneWorkerEnvironmentIdParamName, "", "The ID of the PingOne environment that contains the worker token client used to authenticate.\nAlso configurable via environment variable PINGCTL_PINGONE_WORKER_ENVIRONMENT_ID")
-	cmd.Flags().String(pingoneExportEnvironmentIdParamName, "", "The ID of the PingOne environment to export. (Default: The PingOne worker environment ID)")
+	cmd.Flags().String(pingoneExportEnvironmentIdParamName, "", "The ID of the PingOne environment to export. (Default: The PingOne worker environment ID)\nAlso configurable via environment variable PINGCTL_PINGONE_EXPORT_ENVIRONMENT_ID")
 	cmd.Flags().String(pingoneWorkerClientIdParamName, "", "The ID of the worker app (also the client ID) used to authenticate.\nAlso configurable via environment variable PINGCTL_PINGONE_WORKER_CLIENT_ID")
 	cmd.Flags().String(pingoneWorkerClientSecretParamName, "", "The client secret of the worker app used to authenticate.\nAlso configurable via environment variable PINGCTL_PINGONE_WORKER_CLIENT_SECRET")
 	cmd.Flags().Var(&pingoneRegion, pingoneRegionParamName, fmt.Sprintf("The region of the service. Allowed: %q, %q, %q, %q\nAlso configurable via environment variable PINGCTL_PINGONE_REGION", connector.ENUMREGION_AP, connector.ENUMREGION_CA, connector.ENUMREGION_EU, connector.ENUMREGION_NA))
@@ -164,7 +165,7 @@ func init() {
 	l.Debug().Msgf("Initializing Export Subcommand...")
 }
 
-func initApiClient(ctx context.Context, cmd *cobra.Command) (*sdk.Client, error) {
+func initApiClient(ctx context.Context) (*sdk.Client, error) {
 	l := logger.Get()
 
 	if apiClient != nil {

--- a/cmd/platform/export.go
+++ b/cmd/platform/export.go
@@ -89,21 +89,18 @@ func NewExportCommand() *cobra.Command {
 			}
 
 			// Find the env ID to export. Default to worker env id if not provided by user.
-			var exportEnvID string
-			if viper.IsSet(pingoneExportEnvironmentIdParamConfigKey) {
-				l.Debug().Msgf("Using %s as export environment ID.", pingoneExportEnvironmentIdParamConfigKey)
-				exportEnvID = viper.GetString(pingoneExportEnvironmentIdParamConfigKey)
-			} else {
-				l.Debug().Msgf("Using %s as export environment ID.", pingoneWorkerEnvironmentIdParamConfigKey)
-				exportEnvID = viper.GetString(pingoneWorkerEnvironmentIdParamConfigKey)
-			}
-
+			exportEnvID := viper.GetString(pingoneExportEnvironmentIdParamConfigKey)
 			if exportEnvID == "" {
-				output.Format(cmd, output.CommandOutput{
-					Message: "Failed to determine export environment ID",
-					Result:  output.ENUMCOMMANDOUTPUTRESULT_FAILURE,
-				})
-				return fmt.Errorf("failed to determine export environment ID")
+				exportEnvID = viper.GetString(pingoneWorkerEnvironmentIdParamConfigKey)
+
+				// if the exportEnvID is still empty, this is a problem. Return error.
+				if exportEnvID == "" {
+					output.Format(cmd, output.CommandOutput{
+						Message: "Failed to determine export environment ID",
+						Result:  output.ENUMCOMMANDOUTPUTRESULT_FAILURE,
+					})
+					return fmt.Errorf("failed to determine export environment ID")
+				}
 			}
 
 			// Using the --service parameter(s) provided by user, build list of connectors to export

--- a/cmd/platform/export.go
+++ b/cmd/platform/export.go
@@ -91,8 +91,10 @@ func NewExportCommand() *cobra.Command {
 			// Find the env ID to export. Default to worker env id if not provided by user.
 			var exportEnvID string
 			if viper.IsSet(pingoneExportEnvironmentIdParamConfigKey) {
+				l.Debug().Msgf("Using %s as export environment ID.", pingoneExportEnvironmentIdParamConfigKey)
 				exportEnvID = viper.GetString(pingoneExportEnvironmentIdParamConfigKey)
 			} else {
+				l.Debug().Msgf("Using %s as export environment ID.", pingoneWorkerEnvironmentIdParamConfigKey)
 				exportEnvID = viper.GetString(pingoneWorkerEnvironmentIdParamConfigKey)
 			}
 

--- a/cmd/platform/export.go
+++ b/cmd/platform/export.go
@@ -96,6 +96,14 @@ func NewExportCommand() *cobra.Command {
 				exportEnvID = viper.GetString(pingoneWorkerEnvironmentIdParamConfigKey)
 			}
 
+			if exportEnvID == "" {
+				output.Format(cmd, output.CommandOutput{
+					Message: "Failed to determine export environment ID",
+					Result:  output.ENUMCOMMANDOUTPUTRESULT_FAILURE,
+				})
+				return fmt.Errorf("failed to determine export environment ID")
+			}
+
 			// Using the --service parameter(s) provided by user, build list of connectors to export
 			exportableConnectors := []connector.Exportable{}
 			for _, service := range *multiService.services {

--- a/cmd/platform/export_test.go
+++ b/cmd/platform/export_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/pingidentity/pingctl/cmd"
+	"github.com/pingidentity/pingctl/internal/testutils"
 )
 
 // Test Platform Export Command Executes without issue
@@ -21,12 +22,9 @@ func TestPlatformExportCmd_Execute(t *testing.T) {
 	rootCmd.SetArgs([]string{"platform", "export", "--output-directory", os.TempDir(), "--overwrite"})
 
 	// Execute the command
-	executeErr := rootCmd.Execute()
-	if executeErr != nil {
-		logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
-		if err == nil {
-			t.Logf("Captured Logs: %s", string(logContent[:]))
-		}
-		t.Fatalf("Export Command failed. Make sure to have PingOne env variables set if test is failing.\nErr: %q, Captured StdOut: %s", executeErr, stdout.String())
+	err := rootCmd.Execute()
+	if err != nil {
+		testutils.PrintLogs(t)
+		t.Fatalf("Export Command failed. Make sure to have PingOne env variables set if test is failing.\nErr: %q, Captured StdOut: %s", err, stdout.String())
 	}
 }

--- a/cmd/platform/export_test.go
+++ b/cmd/platform/export_test.go
@@ -3,7 +3,6 @@ package platform_test
 import (
 	"bytes"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/pingidentity/pingctl/cmd"
@@ -20,23 +19,13 @@ func TestPlatformExportCmd_Execute(t *testing.T) {
 	rootCmd.SetErr(&stdout)
 
 	rootCmd.SetArgs([]string{"platform", "export", "--output-directory", os.Getenv("TMPDIR"), "--overwrite"})
-	err := os.Setenv("PINGCTL_LOG_LEVEL", "DEBUG")
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
-
-	logFilepath := filepath.Join(os.Getenv("TMPDIR"), filepath.Base("export_test.log"))
-	err = os.Setenv("PINGCTL_LOG_PATH", logFilepath)
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
 
 	// Execute the command
-	err = rootCmd.Execute()
+	err := rootCmd.Execute()
 	if err != nil {
-		logContents, err := os.ReadFile(logFilepath)
+		logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
 		if err == nil {
-			t.Logf("Captured Logs: %q", logContents)
+			t.Logf("Captured Logs: %q", string(logContent[:]))
 		}
 		t.Fatalf("Export Command failed. Make sure to have PingOne env variables set if test is failing.\nErr: %q, Captured StdOut: %q", err, stdout.String())
 	}

--- a/cmd/platform/export_test.go
+++ b/cmd/platform/export_test.go
@@ -3,7 +3,6 @@ package platform_test
 import (
 	"bytes"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/pingidentity/pingctl/cmd"
@@ -20,8 +19,6 @@ func TestPlatformExportCmd_Execute(t *testing.T) {
 	rootCmd.SetErr(&stdout)
 
 	rootCmd.SetArgs([]string{"platform", "export", "--output-directory", os.TempDir(), "--overwrite"})
-
-	t.Logf("Environ: %s", strings.Join(os.Environ(), "\n"))
 
 	// Execute the command
 	executeErr := rootCmd.Execute()

--- a/cmd/platform/export_test.go
+++ b/cmd/platform/export_test.go
@@ -3,6 +3,7 @@ package platform_test
 import (
 	"bytes"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/pingidentity/pingctl/cmd"
@@ -19,6 +20,8 @@ func TestPlatformExportCmd_Execute(t *testing.T) {
 	rootCmd.SetErr(&stdout)
 
 	rootCmd.SetArgs([]string{"platform", "export", "--output-directory", os.TempDir(), "--overwrite"})
+
+	t.Logf("Environ: %s", strings.Join(os.Environ(), "\n"))
 
 	// Execute the command
 	executeErr := rootCmd.Execute()

--- a/cmd/platform/export_test.go
+++ b/cmd/platform/export_test.go
@@ -18,15 +18,15 @@ func TestPlatformExportCmd_Execute(t *testing.T) {
 	rootCmd.SetOut(&stdout)
 	rootCmd.SetErr(&stdout)
 
-	rootCmd.SetArgs([]string{"platform", "export", "--output-directory", os.Getenv("TMPDIR"), "--overwrite"})
+	rootCmd.SetArgs([]string{"platform", "export", "--output-directory", os.TempDir(), "--overwrite"})
 
 	// Execute the command
 	executeErr := rootCmd.Execute()
 	if executeErr != nil {
 		logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
 		if err == nil {
-			t.Logf("Captured Logs: %q", string(logContent[:]))
+			t.Logf("Captured Logs: %s", string(logContent[:]))
 		}
-		t.Fatalf("Export Command failed. Make sure to have PingOne env variables set if test is failing.\nErr: %q, Captured StdOut: %q", executeErr, stdout.String())
+		t.Fatalf("Export Command failed. Make sure to have PingOne env variables set if test is failing.\nErr: %q, Captured StdOut: %s", executeErr, stdout.String())
 	}
 }

--- a/cmd/platform/export_test.go
+++ b/cmd/platform/export_test.go
@@ -19,6 +19,7 @@ func TestPlatformExportCmd_Execute(t *testing.T) {
 	rootCmd.SetErr(&stdout)
 
 	rootCmd.SetArgs([]string{"platform", "export", "--output-directory", os.Getenv("TMPDIR"), "--overwrite"})
+	os.Setenv("PINGCTL_LOG_LEVEL", "DEBUG")
 
 	// Execute the command
 	err := rootCmd.Execute()

--- a/cmd/platform/export_test.go
+++ b/cmd/platform/export_test.go
@@ -21,12 +21,12 @@ func TestPlatformExportCmd_Execute(t *testing.T) {
 	rootCmd.SetArgs([]string{"platform", "export", "--output-directory", os.Getenv("TMPDIR"), "--overwrite"})
 
 	// Execute the command
-	err := rootCmd.Execute()
-	if err != nil {
+	executeErr := rootCmd.Execute()
+	if executeErr != nil {
 		logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
 		if err == nil {
 			t.Logf("Captured Logs: %q", string(logContent[:]))
 		}
-		t.Fatalf("Export Command failed. Make sure to have PingOne env variables set if test is failing.\nErr: %q, Captured StdOut: %q", err, stdout.String())
+		t.Fatalf("Export Command failed. Make sure to have PingOne env variables set if test is failing.\nErr: %q, Captured StdOut: %q", executeErr, stdout.String())
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -36,13 +36,13 @@ func TestRootCmd_JSONOutput(t *testing.T) {
 	rootCmd.SetErr(&stdout)
 
 	// Execute the root command
-	err := rootCmd.Execute()
-	if err != nil {
+	executeErr := rootCmd.Execute()
+	if executeErr != nil {
 		logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
 		if err == nil {
 			t.Logf("Captured Logs: %s", string(logContent[:]))
 		}
-		t.Fatal(err)
+		t.Fatal(executeErr)
 	}
 
 	outputWithoutJSON := stdout.String()
@@ -57,13 +57,13 @@ func TestRootCmd_JSONOutput(t *testing.T) {
 	rootCmd.SetArgs([]string{"--output=json"})
 
 	// Execute the root command
-	err = rootCmd.Execute()
-	if err != nil {
+	executeErr = rootCmd.Execute()
+	if executeErr != nil {
 		logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
 		if err == nil {
 			t.Logf("Captured Logs: %s", string(logContent[:]))
 		}
-		t.Fatal(err)
+		t.Fatal(executeErr)
 	}
 
 	outputWithJSON := stdout.String()

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,6 +2,7 @@ package cmd_test
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/pingidentity/pingctl/cmd"
@@ -37,6 +38,10 @@ func TestRootCmd_JSONOutput(t *testing.T) {
 	// Execute the root command
 	err := rootCmd.Execute()
 	if err != nil {
+		logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
+		if err == nil {
+			t.Logf("Captured Logs: %s", string(logContent[:]))
+		}
 		t.Fatal(err)
 	}
 
@@ -54,6 +59,10 @@ func TestRootCmd_JSONOutput(t *testing.T) {
 	// Execute the root command
 	err = rootCmd.Execute()
 	if err != nil {
+		logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
+		if err == nil {
+			t.Logf("Captured Logs: %s", string(logContent[:]))
+		}
 		t.Fatal(err)
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,10 +2,10 @@ package cmd_test
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/pingidentity/pingctl/cmd"
+	"github.com/pingidentity/pingctl/internal/testutils"
 )
 
 // Test Root Command Executes without issue
@@ -21,6 +21,7 @@ func TestRootCmd_Execute(t *testing.T) {
 	// Execute the root command
 	err := rootCmd.Execute()
 	if err != nil {
+		testutils.PrintLogs(t)
 		t.Fatalf("Err: %q, Captured StdOut: %q", err, stdout.String())
 	}
 }
@@ -36,13 +37,10 @@ func TestRootCmd_JSONOutput(t *testing.T) {
 	rootCmd.SetErr(&stdout)
 
 	// Execute the root command
-	executeErr := rootCmd.Execute()
-	if executeErr != nil {
-		logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
-		if err == nil {
-			t.Logf("Captured Logs: %s", string(logContent[:]))
-		}
-		t.Fatal(executeErr)
+	err := rootCmd.Execute()
+	if err != nil {
+		testutils.PrintLogs(t)
+		t.Fatal(err)
 	}
 
 	outputWithoutJSON := stdout.String()
@@ -57,13 +55,10 @@ func TestRootCmd_JSONOutput(t *testing.T) {
 	rootCmd.SetArgs([]string{"--output=json"})
 
 	// Execute the root command
-	executeErr = rootCmd.Execute()
-	if executeErr != nil {
-		logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
-		if err == nil {
-			t.Logf("Captured Logs: %s", string(logContent[:]))
-		}
-		t.Fatal(executeErr)
+	err = rootCmd.Execute()
+	if err != nil {
+		testutils.PrintLogs(t)
+		t.Fatal(err)
 	}
 
 	outputWithJSON := stdout.String()

--- a/internal/connector/exportable_resource.go
+++ b/internal/connector/exportable_resource.go
@@ -2,6 +2,8 @@ package connector
 
 import (
 	"context"
+	"regexp"
+	"strings"
 
 	sdk "github.com/patrickcping/pingone-go-sdk-v2/pingone"
 )
@@ -22,4 +24,18 @@ type SDKClientInfo struct {
 type ExportableResource interface {
 	ExportAll() (*[]ImportBlock, error)
 	ResourceType() string
+}
+
+func (b *ImportBlock) Sanitize() {
+
+	// Replace spaces with underscores
+	b.ResourceName = strings.ReplaceAll(b.ResourceName, " ", "_")
+	b.ResourceType = strings.ReplaceAll(b.ResourceType, " ", "_")
+	// Remove all non-Alphanumeric characters/non-underscores
+	re := regexp.MustCompile(`[^a-zA-Z0-9_]+`)
+	b.ResourceName = re.ReplaceAllString(b.ResourceName, "")
+	b.ResourceType = re.ReplaceAllString(b.ResourceType, "")
+	// Make everything lowercase
+	b.ResourceName = strings.ToLower(b.ResourceName)
+	b.ResourceType = strings.ToLower(b.ResourceType)
 }

--- a/internal/connector/exportable_resource.go
+++ b/internal/connector/exportable_resource.go
@@ -27,15 +27,10 @@ type ExportableResource interface {
 }
 
 func (b *ImportBlock) Sanitize() {
-
 	// Replace spaces with underscores
 	b.ResourceName = strings.ReplaceAll(b.ResourceName, " ", "_")
-	b.ResourceType = strings.ReplaceAll(b.ResourceType, " ", "_")
 	// Remove all non-Alphanumeric characters/non-underscores
-	re := regexp.MustCompile(`[^a-zA-Z0-9_]+`)
-	b.ResourceName = re.ReplaceAllString(b.ResourceName, "")
-	b.ResourceType = re.ReplaceAllString(b.ResourceType, "")
+	b.ResourceName = regexp.MustCompile(`[^a-zA-Z0-9_]+`).ReplaceAllString(b.ResourceName, "")
 	// Make everything lowercase
 	b.ResourceName = strings.ToLower(b.ResourceName)
-	b.ResourceType = strings.ToLower(b.ResourceType)
 }

--- a/internal/connector/pingone_platform/resources/pingone_agreement.go
+++ b/internal/connector/pingone_platform/resources/pingone_agreement.go
@@ -17,7 +17,7 @@ type PingoneAgreementResource struct {
 }
 
 // Utility method for creating a PingoneAgreementResource
-func AgreementResource(clientInfo *connector.SDKClientInfo) *PingoneAgreementResource {
+func Agreement(clientInfo *connector.SDKClientInfo) *PingoneAgreementResource {
 	return &PingoneAgreementResource{
 		clientInfo: clientInfo,
 	}

--- a/internal/connector/pingone_platform/resources/pingone_agreement_enable.go
+++ b/internal/connector/pingone_platform/resources/pingone_agreement_enable.go
@@ -17,7 +17,7 @@ type PingoneAgreementEnableResource struct {
 }
 
 // Utility method for creating a PingoneAgreementEnableResource
-func AgreementEnableResource(clientInfo *connector.SDKClientInfo) *PingoneAgreementEnableResource {
+func AgreementEnable(clientInfo *connector.SDKClientInfo) *PingoneAgreementEnableResource {
 	return &PingoneAgreementEnableResource{
 		clientInfo: clientInfo,
 	}
@@ -28,7 +28,7 @@ func (r *PingoneAgreementEnableResource) ExportAll() (*[]connector.ImportBlock, 
 
 	l.Debug().Msgf("Fetching all pingone_agreement_enable resources...")
 
-	agreementImportBlocks, err := AgreementResource(r.clientInfo).ExportAll()
+	agreementImportBlocks, err := Agreement(r.clientInfo).ExportAll()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/connector/pingone_platform/resources/pingone_agreement_localization.go
+++ b/internal/connector/pingone_platform/resources/pingone_agreement_localization.go
@@ -17,7 +17,7 @@ type PingoneAgreementLocalizationResource struct {
 }
 
 // Utility method for creating a PingoneAgreementLocalizationResource
-func AgreementLocalizationResource(clientInfo *connector.SDKClientInfo) *PingoneAgreementLocalizationResource {
+func AgreementLocalization(clientInfo *connector.SDKClientInfo) *PingoneAgreementLocalizationResource {
 	return &PingoneAgreementLocalizationResource{
 		clientInfo: clientInfo,
 	}

--- a/internal/connector/pingone_platform/resources/pingone_agreement_localization_enable.go
+++ b/internal/connector/pingone_platform/resources/pingone_agreement_localization_enable.go
@@ -17,7 +17,7 @@ type PingoneAgreementLocalizationEnableResource struct {
 }
 
 // Utility method for creating a PingoneAgreementLocalizationEnableResource
-func AgreementLocalizationEnableResource(clientInfo *connector.SDKClientInfo) *PingoneAgreementLocalizationEnableResource {
+func AgreementLocalizationEnable(clientInfo *connector.SDKClientInfo) *PingoneAgreementLocalizationEnableResource {
 	return &PingoneAgreementLocalizationEnableResource{
 		clientInfo: clientInfo,
 	}
@@ -28,7 +28,7 @@ func (r *PingoneAgreementLocalizationEnableResource) ExportAll() (*[]connector.I
 
 	l.Debug().Msgf("Fetching all pingone_agreement_localization_enable resources...")
 
-	localizationImportBlocks, err := AgreementLocalizationResource(r.clientInfo).ExportAll()
+	localizationImportBlocks, err := AgreementLocalization(r.clientInfo).ExportAll()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/connector/pingone_platform/resources/pingone_agreement_localization_revision.go
+++ b/internal/connector/pingone_platform/resources/pingone_agreement_localization_revision.go
@@ -17,7 +17,7 @@ type PingoneAgreementLocalizationRevisionResource struct {
 }
 
 // Utility method for creating a PingoneAgreementLocalizationRevisionResource
-func AgreementLocalizationRevisionResource(clientInfo *connector.SDKClientInfo) *PingoneAgreementLocalizationRevisionResource {
+func AgreementLocalizationRevision(clientInfo *connector.SDKClientInfo) *PingoneAgreementLocalizationRevisionResource {
 	return &PingoneAgreementLocalizationRevisionResource{
 		clientInfo: clientInfo,
 	}

--- a/internal/connector/pingone_platform/resources/pingone_branding_settings.go
+++ b/internal/connector/pingone_platform/resources/pingone_branding_settings.go
@@ -15,7 +15,7 @@ type PingoneBrandingSettingsResource struct {
 }
 
 // Utility method for creating a PingoneBrandingSettingsResource
-func BrandingSettingsResource(clientInfo *connector.SDKClientInfo) *PingoneBrandingSettingsResource {
+func BrandingSettings(clientInfo *connector.SDKClientInfo) *PingoneBrandingSettingsResource {
 	return &PingoneBrandingSettingsResource{
 		clientInfo: clientInfo,
 	}

--- a/internal/connector/pingone_platform/resources/pingone_branding_theme.go
+++ b/internal/connector/pingone_platform/resources/pingone_branding_theme.go
@@ -17,7 +17,7 @@ type PingoneBrandingThemeResource struct {
 }
 
 // Utility method for creating a PingoneBrandingThemeResource
-func BrandingThemeResource(clientInfo *connector.SDKClientInfo) *PingoneBrandingThemeResource {
+func BrandingTheme(clientInfo *connector.SDKClientInfo) *PingoneBrandingThemeResource {
 	return &PingoneBrandingThemeResource{
 		clientInfo: clientInfo,
 	}

--- a/internal/connector/pingone_platform/resources/pingone_branding_theme_default.go
+++ b/internal/connector/pingone_platform/resources/pingone_branding_theme_default.go
@@ -15,7 +15,7 @@ type PingoneBrandingThemeDefaultResource struct {
 }
 
 // Utility method for creating a PingoneBrandingThemeDefaultResource
-func BrandingThemeDefaultResource(clientInfo *connector.SDKClientInfo) *PingoneBrandingThemeDefaultResource {
+func BrandingThemeDefault(clientInfo *connector.SDKClientInfo) *PingoneBrandingThemeDefaultResource {
 	return &PingoneBrandingThemeDefaultResource{
 		clientInfo: clientInfo,
 	}

--- a/internal/connector/pingone_platform/resources/pingone_certificate.go
+++ b/internal/connector/pingone_platform/resources/pingone_certificate.go
@@ -17,7 +17,7 @@ type PingoneCertificateResource struct {
 }
 
 // Utility method for creating a PingoneCertificateResource
-func CertificateResource(clientInfo *connector.SDKClientInfo) *PingoneCertificateResource {
+func Certificate(clientInfo *connector.SDKClientInfo) *PingoneCertificateResource {
 	return &PingoneCertificateResource{
 		clientInfo: clientInfo,
 	}

--- a/internal/connector/pingone_platform/resources/pingone_custom_domain.go
+++ b/internal/connector/pingone_platform/resources/pingone_custom_domain.go
@@ -1,0 +1,71 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/logger"
+)
+
+// Verify that the resource satisfies the exportable resource interface
+var (
+	_ connector.ExportableResource = &PingoneCustomDomainResource{}
+)
+
+type PingoneCustomDomainResource struct {
+	clientInfo *connector.SDKClientInfo
+}
+
+// Utility method for creating a PingoneCustomDomainResource
+func CustomDomain(clientInfo *connector.SDKClientInfo) *PingoneCustomDomainResource {
+	return &PingoneCustomDomainResource{
+		clientInfo: clientInfo,
+	}
+}
+
+func (r *PingoneCustomDomainResource) ExportAll() (*[]connector.ImportBlock, error) {
+	l := logger.Get()
+
+	l.Debug().Msgf("Fetching all pingone_custom_domain resources...")
+
+	entityArray, response, err := r.clientInfo.ApiClient.ManagementAPIClient.CustomDomainsApi.ReadAllDomains(r.clientInfo.Context, r.clientInfo.ExportEnvironmentID).Execute()
+	defer response.Body.Close()
+	if err != nil {
+		l.Error().Err(err).Msgf("ReadAllDomains Response Code: %s\nResponse Body: %s", response.Status, response.Body)
+		return nil, err
+	}
+
+	if entityArray == nil {
+		l.Error().Msgf("Returned ReadAllDomains() entity array is nil.")
+		l.Error().Msgf("ReadAllDomains Response Code: %s\nResponse Body: %s", response.Status, response.Body)
+		return nil, fmt.Errorf("failed to fetch pingone_custom_domain resources via ReadAllDomains()")
+	}
+
+	embedded, embeddedOk := entityArray.GetEmbeddedOk()
+	if !embeddedOk {
+		l.Error().Msgf("Returned ReadAllDomains() embedded data is nil.")
+		l.Error().Msgf("ReadAllDomains Response Code: %s\nResponse Body: %s", response.Status, response.Body)
+		return nil, fmt.Errorf("failed to fetch pingone_custom_domain resources via ReadAllDomains()")
+	}
+
+	importBlocks := []connector.ImportBlock{}
+
+	for _, customDomain := range embedded.GetCustomDomains() {
+		customDomainName, customDomainNameOk := customDomain.GetDomainNameOk()
+		customDomainId, customDomainIdOk := customDomain.GetIdOk()
+
+		if customDomainIdOk && customDomainNameOk {
+			importBlocks = append(importBlocks, connector.ImportBlock{
+				ResourceType: r.ResourceType(),
+				ResourceName: *customDomainName,
+				ResourceID:   fmt.Sprintf("%s/%s", r.clientInfo.ExportEnvironmentID, *customDomainId),
+			})
+		}
+	}
+
+	return &importBlocks, nil
+}
+
+func (r *PingoneCustomDomainResource) ResourceType() string {
+	return "pingone_custom_domain"
+}

--- a/internal/testutils/helper.go
+++ b/internal/testutils/helper.go
@@ -1,0 +1,16 @@
+package testutils
+
+import (
+	"os"
+	"testing"
+)
+
+// Utility method to print log file if present.
+func PrintLogs(t *testing.T) {
+	t.Helper()
+
+	logContent, err := os.ReadFile(os.Getenv("PINGCTL_LOG_PATH"))
+	if err == nil {
+		t.Logf("Captured Logs: %s", string(logContent[:]))
+	}
+}


### PR DESCRIPTION
- Fix bug where export environment ID was not being bound to viper configuration properly.
- Remove unneeded parameters from initApiClient()
- Updated --pingone-export-environment-id help message to include the available environment variable.
- Added the ImportBlock Sanitize() function to make sure the "to" field is lowercase, without special characters, and spaces replaced with underscores.
- Remove "Resource" from creation methods for each exportable resource following effective go conventions.
- Do not create import.tf file for empty exported resources.