### PR TITLE
Add UserAgent suffix to PingOne client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .vscode/*
 go.work
 go.work.sum
+
+vendor
+env*.sh


### PR DESCRIPTION
Adding a UserAgent suffix to the PingOne client, including the version of the CLI tool.

Also added lines to the gitignore to prevent unnecessary files in PR for local development