### PR TITLE
PDI-1632: Add Testing Framework to PingCTL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@
 .vscode/*
 go.work
 go.work.sum
-
+gen
 vendor
 env*.sh

--- a/internal/connector/pingone/platform/resources/pingone_agreement_enable_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_agreement_enable_test.go
@@ -28,10 +28,5 @@ func TestAgreementEnableExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_agreement_localization_enable_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_agreement_localization_enable_test.go
@@ -28,10 +28,5 @@ func TestAgreementLocalizationEnableExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_agreement_localization_revision_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_agreement_localization_revision_test.go
@@ -33,10 +33,5 @@ func TestAgreementLocalizationRevisionExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_agreement_localization_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_agreement_localization_test.go
@@ -28,10 +28,5 @@ func TestAgreementLocalizationExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_agreement_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_agreement_test.go
@@ -28,10 +28,5 @@ func TestAgreementExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_branding_settings_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_branding_settings_test.go
@@ -22,10 +22,5 @@ func TestBrandingSettingsExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_branding_theme_default_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_branding_theme_default_test.go
@@ -22,10 +22,5 @@ func TestBrandingThemeDefaultExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_branding_theme_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_branding_theme_test.go
@@ -33,10 +33,5 @@ func TestBrandingThemeExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_certificate_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_certificate_test.go
@@ -28,10 +28,5 @@ func TestCertificateExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_custom_domain_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_custom_domain_test.go
@@ -23,10 +23,5 @@ func TestCustomDomainExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_environment_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_environment_test.go
@@ -22,10 +22,5 @@ func TestEnvironmentExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_form_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_form_test.go
@@ -23,10 +23,5 @@ func TestFormExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_forms_recaptcha_v2_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_forms_recaptcha_v2_test.go
@@ -22,10 +22,5 @@ func TestFormRecaptchaV2Export(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_gateway_credential_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_gateway_credential_test.go
@@ -53,10 +53,5 @@ func TestGatewayCredentialExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_gateway_role_assignment_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_gateway_role_assignment_test.go
@@ -38,10 +38,5 @@ func TestGatewayRoleAssignmentExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_gateway_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_gateway_test.go
@@ -43,10 +43,5 @@ func TestGatewayExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_identity_propagation_plan_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_identity_propagation_plan_test.go
@@ -23,10 +23,5 @@ func TestIdentityPropagationPlanExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_key_rotation_policy_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_key_rotation_policy_test.go
@@ -23,10 +23,5 @@ func TestKeyRotationPolicyExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_key_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_key_test.go
@@ -38,10 +38,5 @@ func TestKeyExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_language_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_language_test.go
@@ -103,10 +103,5 @@ func TestLanguageExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_notification_policy_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_notification_policy_test.go
@@ -28,10 +28,5 @@ func TestNotificationPolicyExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_notification_settings_email_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_notification_settings_email_test.go
@@ -22,10 +22,5 @@ func TestNotificationSettingsEmailExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_notification_settings_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_notification_settings_test.go
@@ -22,10 +22,5 @@ func TestNotificationSettingsExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_notification_template_content_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_notification_template_content_test.go
@@ -723,10 +723,5 @@ func TestNotificationTemplateContentExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_phone_delivery_settings_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_phone_delivery_settings_test.go
@@ -23,10 +23,5 @@ func TestPhoneDeliverySettingsExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_role_assignment_user_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_role_assignment_user_test.go
@@ -63,10 +63,5 @@ func TestRoleAssignmentUserExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_system_application_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_system_application_test.go
@@ -28,10 +28,5 @@ func TestSystemApplicationExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_trusted_email_address_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_trusted_email_address_test.go
@@ -16,10 +16,5 @@ func TestTrustedEmailAddressExport(t *testing.T) {
 	// Defined the expected ImportBlocks for the resource
 	expectedImportBlocks := []connector.ImportBlock{}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_trusted_email_domain_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_trusted_email_domain_test.go
@@ -38,10 +38,5 @@ func TestTrustedEmailDomainExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/platform/resources/pingone_webhook_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_webhook_test.go
@@ -23,10 +23,5 @@ func TestWebhookExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_application_attribute_mapping_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_application_attribute_mapping_test.go
@@ -1,0 +1,57 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestApplicationAttributeMappingExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.ApplicationAttributeMapping(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_application_attribute_mapping",
+			ResourceName: "Example OAuth App_sub",
+			ResourceID:   fmt.Sprintf("%s/2a7c1b5d-415b-4fb5-a6c0-1e290f776785/f6d41400-e571-432e-9151-4ff06e0b51ce", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_attribute_mapping",
+			ResourceName: "Getting Started Application_sub",
+			ResourceID:   fmt.Sprintf("%s/3da7aae6-92e5-4295-a37c-8515d1f2cd86/f6d41400-e571-432e-9151-4ff06e0b51ce", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_attribute_mapping",
+			ResourceName: "OAuth Worker App_sub",
+			ResourceID:   fmt.Sprintf("%s/9d6c443b-6329-4d3c-949e-880eda3b9599/f6d41400-e571-432e-9151-4ff06e0b51ce", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_attribute_mapping",
+			ResourceName: "PingOne DaVinci Connection_sub",
+			ResourceID:   fmt.Sprintf("%s/7b621870-7124-4426-b432-6c675642afcb/f6d41400-e571-432e-9151-4ff06e0b51ce", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_attribute_mapping",
+			ResourceName: "test app_sub",
+			ResourceID:   fmt.Sprintf("%s/a4cbf57e-fa2c-452f-bbc8-f40b551da0e2/f6d41400-e571-432e-9151-4ff06e0b51ce", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_attribute_mapping",
+			ResourceName: "Worker App_sub",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/f6d41400-e571-432e-9151-4ff06e0b51ce", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_application_attribute_mapping_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_application_attribute_mapping_test.go
@@ -48,10 +48,5 @@ func TestApplicationAttributeMappingExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_application_flow_policy_assignment_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_application_flow_policy_assignment_test.go
@@ -28,10 +28,5 @@ func TestApplicationFlowPolicyAssignmentExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_application_flow_policy_assignment_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_application_flow_policy_assignment_test.go
@@ -1,0 +1,37 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestApplicationFlowPolicyAssignmentExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.ApplicationFlowPolicyAssignment(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_application_flow_policy_assignment",
+			ResourceName: "Getting Started Application_PingOne - Sign On and Registration",
+			ResourceID:   fmt.Sprintf("%s/3da7aae6-92e5-4295-a37c-8515d1f2cd86/0b08c0c3-db40-4be2-aa5b-eb0e17396a75", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_flow_policy_assignment",
+			ResourceName: "test app_PingOne - Sign On and Registration",
+			ResourceID:   fmt.Sprintf("%s/a4cbf57e-fa2c-452f-bbc8-f40b551da0e2/87a6045e-fa59-41fd-9a06-867ef8cc7a0c", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_application_resource_grant_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_application_resource_grant_test.go
@@ -38,10 +38,5 @@ func TestApplicationResourceGrantExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_application_resource_grant_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_application_resource_grant_test.go
@@ -1,0 +1,47 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestApplicationResourceGrantExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.ApplicationResourceGrant(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_application_resource_grant",
+			ResourceName: "PingOne Application Portal_openid",
+			ResourceID:   fmt.Sprintf("%s/92a3765c-e135-4afa-8b12-4469672ac8a9/7e1e25cd-a29e-43b3-bf4a-317ffaabb49c", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_resource_grant",
+			ResourceName: "PingOne Application Portal_PingOne API",
+			ResourceID:   fmt.Sprintf("%s/92a3765c-e135-4afa-8b12-4469672ac8a9/cf7c2b8e-718c-4ccc-ad1e-1612724baf8e", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_resource_grant",
+			ResourceName: "PingOne Self-Service - MyAccount_PingOne API",
+			ResourceID:   fmt.Sprintf("%s/4ce54d01-5138-4c56-8175-4f02f69278f5/78d28a77-127d-434b-ae30-71bc18c97902", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_resource_grant",
+			ResourceName: "PingOne Self-Service - MyAccount_openid",
+			ResourceID:   fmt.Sprintf("%s/4ce54d01-5138-4c56-8175-4f02f69278f5/88063562-7b01-4dbc-b638-119435f74860", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_application_role_assignment.go
+++ b/internal/connector/pingone/sso/resources/pingone_application_role_assignment.go
@@ -84,7 +84,7 @@ func (r *PingoneApplicationRoleAssignmentResource) ExportAll() (*[]connector.Imp
 				return nil, err
 			}
 
-			for _, roleAssignment := range appRoleAssignmentsEmbedded.GetRoleAssignments() {
+			for roleAssignmentIndex, roleAssignment := range appRoleAssignmentsEmbedded.GetRoleAssignments() {
 				roleAssignmentId, roleAssignmentIdOk := roleAssignment.GetIdOk()
 				roleAssignmentRole, roleAssignmentRoleOk := roleAssignment.GetRoleOk()
 				if roleAssignmentIdOk && roleAssignmentRoleOk {
@@ -100,7 +100,7 @@ func (r *PingoneApplicationRoleAssignmentResource) ExportAll() (*[]connector.Imp
 							if apiRoleNameOk {
 								importBlocks = append(importBlocks, connector.ImportBlock{
 									ResourceType: r.ResourceType(),
-									ResourceName: fmt.Sprintf("%s_%s", *appName, *apiRoleName),
+									ResourceName: fmt.Sprintf("%s_%s_%d", *appName, *apiRoleName, (roleAssignmentIndex + 1)),
 									ResourceID:   fmt.Sprintf("%s/%s/%s", r.clientInfo.ExportEnvironmentID, *appId, *roleAssignmentId),
 								})
 							}

--- a/internal/connector/pingone/sso/resources/pingone_application_role_assignment_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_application_role_assignment_test.go
@@ -148,10 +148,5 @@ func TestApplicationRoleAssignmentExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_application_role_assignment_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_application_role_assignment_test.go
@@ -1,0 +1,157 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestApplicationRoleAssignmentExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.ApplicationRoleAssignment(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "OAuth Worker App_PingFederate Crypto Administrator_1",
+			ResourceID:   fmt.Sprintf("%s/9d6c443b-6329-4d3c-949e-880eda3b9599/d4aa4aec-c521-4538-ab76-8776355d2b22", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "OAuth Worker App_PingFederate User Administrator_2",
+			ResourceID:   fmt.Sprintf("%s/9d6c443b-6329-4d3c-949e-880eda3b9599/9f431f95-8df7-43cb-8419-e2b3898ca8c4", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "OAuth Worker App_PingFederate Administrator_3",
+			ResourceID:   fmt.Sprintf("%s/9d6c443b-6329-4d3c-949e-880eda3b9599/28607a1f-b0b3-4c43-8807-4bf8a93c8d07", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "OAuth Worker App_PingFederate Expression Administrator_4",
+			ResourceID:   fmt.Sprintf("%s/9d6c443b-6329-4d3c-949e-880eda3b9599/cbd5b6a0-1748-4ca6-b252-e02fd843897e", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "PingOne DaVinci Connection_Identity Data Admin_1",
+			ResourceID:   fmt.Sprintf("%s/7b621870-7124-4426-b432-6c675642afcb/4331fc1a-434c-4cee-ba2a-ceb57974550c", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "PingOne DaVinci Connection_DaVinci Admin_2",
+			ResourceID:   fmt.Sprintf("%s/7b621870-7124-4426-b432-6c675642afcb/ebcdd4c7-0014-4eb5-9aa9-15af45795c15", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "PingOne DaVinci Connection_Environment Admin_3",
+			ResourceID:   fmt.Sprintf("%s/7b621870-7124-4426-b432-6c675642afcb/9e1d7f96-c4a9-49d3-bb2d-d2b1fef197dd", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "Worker App_Identity Data Admin_1",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/9225c10f-b902-4107-8aba-b15b219d6c0e", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "Worker App_Client Application Developer_2",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/0081f0ab-d02c-4718-b10c-35fd48b82f47", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "Worker App_Identity Data Read Only_3",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/a0f34409-4d1b-4b22-911a-7b4a61ac68b1", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "Worker App_Identity Data Admin_4",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/970667f1-26d5-4021-809f-e5d17fe44a7d", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "Worker App_Client Application Developer_5",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/785b582f-eaf2-4a0b-ac8e-b7c7f9665762", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "Worker App_Identity Data Read Only_6",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/91562725-239b-4854-8cef-c4efe35ea77f", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "Worker App_Identity Data Admin_7",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/ed54c262-38ab-4874-a206-2d13e34f21fd", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "Worker App_Client Application Developer_8",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/3f112aa9-b712-4388-821d-8f37a429b071", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "Worker App_Identity Data Read Only_9",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/1395d969-6527-45f4-b356-4ef36a5d6349", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "Worker App_PingFederate Crypto Administrator_10",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/c01ef5c4-74c4-4074-8929-b0836aa9a783", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "Worker App_DaVinci Admin_11",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/9bdbe295-e199-4952-8717-3405112eccad", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "Worker App_Organization Admin_12",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/b57756a8-d9c6-4fbc-95d4-9d2aabf801e0", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "Worker App_Environment Admin_13",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/3e77cca6-8820-4eb6-bcfd-761cf4e74ad1", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "Worker App_PingFederate User Administrator_14",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/6600fad1-82c4-412f-aa2c-22e8668d8c3a", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "Worker App_Configuration Read Only_15",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/6f01ea75-5e04-45a5-8614-186b58f9eb4e", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "Worker App_PingFederate Auditor_16",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/cf1edf79-fd13-4d72-a049-7bdc4377ee0c", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "Worker App_PingFederate Administrator_17",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/530824c1-675f-4282-8a61-6567fc3afee6", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "Worker App_DaVinci Admin Read Only_18",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/e82d85ed-8687-4724-87ad-7f138cdbe673", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_role_assignment",
+			ResourceName: "Worker App_PingFederate Expression Administrator_19",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/c090f7c9-4419-447b-8316-baf3e70030bc", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_application_secret_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_application_secret_test.go
@@ -48,10 +48,5 @@ func TestApplicationSecretExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_application_secret_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_application_secret_test.go
@@ -1,0 +1,57 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestApplicationSecretExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.ApplicationSecret(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_application_secret",
+			ResourceName: "Example OAuth App_secret",
+			ResourceID:   fmt.Sprintf("%s/2a7c1b5d-415b-4fb5-a6c0-1e290f776785", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_secret",
+			ResourceName: "Getting Started Application_secret",
+			ResourceID:   fmt.Sprintf("%s/3da7aae6-92e5-4295-a37c-8515d1f2cd86", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_secret",
+			ResourceName: "OAuth Worker App_secret",
+			ResourceID:   fmt.Sprintf("%s/9d6c443b-6329-4d3c-949e-880eda3b9599", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_secret",
+			ResourceName: "PingOne DaVinci Connection_secret",
+			ResourceID:   fmt.Sprintf("%s/7b621870-7124-4426-b432-6c675642afcb", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_secret",
+			ResourceName: "test app_secret",
+			ResourceID:   fmt.Sprintf("%s/a4cbf57e-fa2c-452f-bbc8-f40b551da0e2", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application_secret",
+			ResourceName: "Worker App_secret",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_application_sign_on_policy_assignment_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_application_sign_on_policy_assignment_test.go
@@ -23,10 +23,5 @@ func TestApplicationSignOnPolicyAssignmentExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_application_sign_on_policy_assignment_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_application_sign_on_policy_assignment_test.go
@@ -1,0 +1,32 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestApplicationSignOnPolicyAssignmentExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.ApplicationSignOnPolicyAssignment(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_application_sign_on_policy_assignment",
+			ResourceName: "Example OAuth App_Single_Factor",
+			ResourceID:   fmt.Sprintf("%s/2a7c1b5d-415b-4fb5-a6c0-1e290f776785/056ed696-f2e9-44b1-8d2c-68e690cd1f24", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_application_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_application_test.go
@@ -48,10 +48,5 @@ func TestApplicationExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_application_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_application_test.go
@@ -1,0 +1,57 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestApplicationExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.Application(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_application",
+			ResourceName: "Example OAuth App",
+			ResourceID:   fmt.Sprintf("%s/2a7c1b5d-415b-4fb5-a6c0-1e290f776785", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application",
+			ResourceName: "Getting Started Application",
+			ResourceID:   fmt.Sprintf("%s/3da7aae6-92e5-4295-a37c-8515d1f2cd86", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application",
+			ResourceName: "OAuth Worker App",
+			ResourceID:   fmt.Sprintf("%s/9d6c443b-6329-4d3c-949e-880eda3b9599", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application",
+			ResourceName: "PingOne DaVinci Connection",
+			ResourceID:   fmt.Sprintf("%s/7b621870-7124-4426-b432-6c675642afcb", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application",
+			ResourceName: "test app",
+			ResourceID:   fmt.Sprintf("%s/a4cbf57e-fa2c-452f-bbc8-f40b551da0e2", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_application",
+			ResourceName: "Worker App",
+			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_group_nesting_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_group_nesting_test.go
@@ -1,0 +1,32 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestGroupNestingExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.GroupNesting(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_group_nesting",
+			ResourceName: "My parent group_My nested group",
+			ResourceID:   fmt.Sprintf("%s/298cf355-6806-4058-b87e-1ae92c7fb13b/d12ae346-c596-438c-95e3-3d76f364d527", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_group_nesting_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_group_nesting_test.go
@@ -23,10 +23,5 @@ func TestGroupNestingExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_group_role_assignment_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_group_role_assignment_test.go
@@ -28,10 +28,5 @@ func TestGroupRoleAssignmentExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_group_role_assignment_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_group_role_assignment_test.go
@@ -1,0 +1,37 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestGroupRoleAssignmentExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.GroupRoleAssignment(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_group_role_assignment",
+			ResourceName: "testing_Client Application Developer_1",
+			ResourceID:   fmt.Sprintf("%s/b6924f30-73ca-4d3c-964b-90c77adce6a7/1db1accc-f63f-4f03-ab62-c767398fa730", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_group_role_assignment",
+			ResourceName: "testing_Identity Data Read Only_2",
+			ResourceID:   fmt.Sprintf("%s/b6924f30-73ca-4d3c-964b-90c77adce6a7/53a88921-2a9f-44f1-958e-3db9be3f8c69", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_group_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_group_test.go
@@ -38,10 +38,5 @@ func TestGroupExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_group_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_group_test.go
@@ -1,0 +1,47 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestGroupExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.Group(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_group",
+			ResourceName: "test group",
+			ResourceID:   fmt.Sprintf("%s/ebdf1771-4f43-4fa6-bb9a-ec17333e5ca7", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_group",
+			ResourceName: "testing",
+			ResourceID:   fmt.Sprintf("%s/b6924f30-73ca-4d3c-964b-90c77adce6a7", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_group",
+			ResourceName: "My parent group",
+			ResourceID:   fmt.Sprintf("%s/298cf355-6806-4058-b87e-1ae92c7fb13b", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_group",
+			ResourceName: "My nested group",
+			ResourceID:   fmt.Sprintf("%s/d12ae346-c596-438c-95e3-3d76f364d527", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_identity_provider_attribute_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_identity_provider_attribute_test.go
@@ -23,10 +23,5 @@ func TestIdentityProviderAttributeExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_identity_provider_attribute_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_identity_provider_attribute_test.go
@@ -1,0 +1,32 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestIdentityProviderAttributeExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.IdentityProviderAttribute(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_identity_provider_attribute",
+			ResourceName: "Test IdP_username",
+			ResourceID:   fmt.Sprintf("%s/a99df558-7090-4303-8f35-860ac660e371/51a036c6-41ed-44f7-bd1d-eacaa2a1feab", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_identity_provider_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_identity_provider_test.go
@@ -1,0 +1,32 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestIdentityProviderExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.IdentityProvider(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_identity_provider",
+			ResourceName: "Test IdP",
+			ResourceID:   fmt.Sprintf("%s/a99df558-7090-4303-8f35-860ac660e371", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_identity_provider_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_identity_provider_test.go
@@ -23,10 +23,5 @@ func TestIdentityProviderExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_password_policy_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_password_policy_test.go
@@ -1,0 +1,47 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestPasswordPolicyExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.PasswordPolicy(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_password_policy",
+			ResourceName: "Standard",
+			ResourceID:   fmt.Sprintf("%s/10c1f1bc-3dff-49ca-9abb-cf034b728793", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_password_policy",
+			ResourceName: "Basic",
+			ResourceID:   fmt.Sprintf("%s/48641620-f51d-4675-86e1-e45d378ac0b2", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_password_policy",
+			ResourceName: "Passphrase",
+			ResourceID:   fmt.Sprintf("%s/686e2710-d59f-484a-8ba5-47959753012c", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_password_policy",
+			ResourceName: "LDAP Gateway Policy",
+			ResourceID:   fmt.Sprintf("%s/c79032d2-b156-46a5-a9c9-7d18e93095b7", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_password_policy_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_password_policy_test.go
@@ -38,10 +38,5 @@ func TestPasswordPolicyExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_population_default_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_population_default_test.go
@@ -22,10 +22,5 @@ func TestPopulationDefaultExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_population_default_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_population_default_test.go
@@ -1,0 +1,31 @@
+package resources_test
+
+import (
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestPopulationDefaultExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.PopulationDefault(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_population_default",
+			ResourceName: "population_default",
+			ResourceID:   testutils.GetEnvironmentID(),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_population_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_population_test.go
@@ -1,0 +1,37 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestPopulationExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.Population(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_population",
+			ResourceName: "Default",
+			ResourceID:   fmt.Sprintf("%s/720da2ce-4dd0-48d9-af75-aeadbda1860d", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_population",
+			ResourceName: "LDAP Gateway Population",
+			ResourceID:   fmt.Sprintf("%s/374fdb3c-4e94-4547-838a-0c200b9a7c70", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_population_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_population_test.go
@@ -28,10 +28,5 @@ func TestPopulationExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_resource_attribute_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_resource_attribute_test.go
@@ -153,10 +153,5 @@ func TestResourceAttributeExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_resource_attribute_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_resource_attribute_test.go
@@ -1,0 +1,162 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestResourceAttributeExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.ResourceAttribute(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "test_sub",
+			ResourceID:   fmt.Sprintf("%s/4b9ef858-62ce-4bd0-9186-997b8527529d/c82b24b9-7ea3-4de4-8840-50b6c3cb1387", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "testing_sub",
+			ResourceID:   fmt.Sprintf("%s/52afd89f-f3c0-4c78-b896-432c0a07329b/a7cf0daf-0e30-4ae5-bf88-7c5dc629d7cf", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_locale",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/0122f755-ac5d-4bc1-a755-0f56b6f582ec", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_preferred_username",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/09c1e110-7b3b-4f2d-a1ab-7d3054df8aa6", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_email",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/0b230ac5-25a4-4012-a393-e2529d91d4df", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_email_verified",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/1754e8e0-97b5-4477-b76e-a97d6d4fcb8d", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_phone_number",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/1b6c9496-a281-4379-a8ef-dc5b60cb1bf4", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_nickname",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/1c822a3c-52fb-4cb2-b8c7-99800d32221a", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_address.postal_code",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/1fdeb8af-3f4d-4979-a4eb-2344694f9ec2", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_name",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/28ce7067-77cb-460c-ad61-c7300b6b2ceb", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_updated_at",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/310677e7-2ece-4740-a17a-ec5cd9412b5c", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_family_name",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/37c492db-521d-4ef5-9fb2-dec64bb1de1e", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_profile",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/3c3f3bfe-d096-4f0e-9f9e-1ce9633cac5d", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_address.formatted",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/3dc6971b-d7e8-4019-8502-d43dc0ced872", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_address.region",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/4dab2957-276b-4132-886f-fd217d21c01d", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_phone_number_verified",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/791968e4-08bb-4aa8-bfc3-a28287fe0070", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_website",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/8447184f-1d5c-43cd-951b-a15c924b5bae", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_given_name",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/8bf9debc-5f13-45e4-81ba-cae3bc1c0d77", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_birthdate",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/91234ec7-61e8-4c5b-83f3-a08388e1a5f7", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_address.locality",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/b1f8538f-2b55-43ff-9b78-238fcad14b9d", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_zoneinfo",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/b298df9c-75c8-4b5a-b1a9-97b71bce415f", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_gender",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/c24c29ad-14d9-407e-a7c9-acb22a4792ce", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_address.street_address",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/d1c9d1eb-f988-4983-93e1-97ed6f0d835f", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_address.country",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/d2964153-b987-4688-a5dc-09b7a1d52667", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_exampleAttribute",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/dc35abb7-79bc-4449-8fcc-265fbb39345f", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_picture",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/dc9cd3f2-2076-44d2-b760-100a2beb49db", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_attribute",
+			ResourceName: "openid_middle_name",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/fd6180af-b339-47bb-a9e3-6e02b69fb7ad", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_resource_scope_openid_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_resource_scope_openid_test.go
@@ -63,10 +63,5 @@ func TestResourceScopeOpenIdExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_resource_scope_openid_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_resource_scope_openid_test.go
@@ -1,0 +1,72 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestResourceScopeOpenIdExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.ResourceScopeOpenId(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_resource_scope_openid",
+			ResourceName: "openid_profile",
+			ResourceID:   fmt.Sprintf("%s/5a2881ba-affc-4556-a9ff-ad662ea84e89", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_openid",
+			ResourceName: "openid_newscope2",
+			ResourceID:   fmt.Sprintf("%s/5f07b021-5f0e-47d0-a62b-1e983bdff753", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_openid",
+			ResourceName: "openid_openid",
+			ResourceID:   fmt.Sprintf("%s/6f095311-2cb9-4414-b30f-af8ee5e11e34", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_openid",
+			ResourceName: "openid_newscope",
+			ResourceID:   fmt.Sprintf("%s/792fa804-8aae-43c8-bea7-ea2dbbb1ca88", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_openid",
+			ResourceName: "openid_email",
+			ResourceID:   fmt.Sprintf("%s/a95eb903-b691-4aa9-91df-8b02d69816df", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_openid",
+			ResourceName: "openid_test",
+			ResourceID:   fmt.Sprintf("%s/d4213f0d-e1fc-42db-bcc6-dfad730f7be7", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_openid",
+			ResourceName: "openid_phone",
+			ResourceID:   fmt.Sprintf("%s/dad64f0c-187e-4991-a5b3-c4e53a4167e5", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_openid",
+			ResourceName: "openid_testing",
+			ResourceID:   fmt.Sprintf("%s/eb7e9feb-6076-4a2e-9e9e-5c9c0a503606", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_openid",
+			ResourceName: "openid_address",
+			ResourceID:   fmt.Sprintf("%s/fcd04665-fb97-4943-9c88-427331ebe930", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_resource_scope_pingone_api_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_resource_scope_pingone_api_test.go
@@ -1,0 +1,137 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestResourceScopePingOneApiExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.ResourceScopePingOneApi(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:read:user",
+			ResourceID:   fmt.Sprintf("%s/089adcde-be64-4e7e-9a5a-dda60ce38a9f", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:read:user:2",
+			ResourceID:   fmt.Sprintf("%s/83d8ee1d-938f-4287-9792-aa808dc0cad9", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:update:user",
+			ResourceID:   fmt.Sprintf("%s/d5bd66de-8044-41c5-aed2-278b6cf47dad", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:update:userMfaEnabled",
+			ResourceID:   fmt.Sprintf("%s/2a8c4a72-b7fb-4093-9e9f-4b2d6040749a", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:validate:userPassword",
+			ResourceID:   fmt.Sprintf("%s/a550ce20-1b72-4bfe-a756-20f21647d1cf", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:reset:userPassword",
+			ResourceID:   fmt.Sprintf("%s/a112f3ef-cfa2-4cde-89d6-965ca88096c5", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:read:userPassword",
+			ResourceID:   fmt.Sprintf("%s/ac9a1304-419b-4786-9113-1b5c5df9db11", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:read:device",
+			ResourceID:   fmt.Sprintf("%s/194a59ec-fae0-462f-ad73-a3fbbdf2430e", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:update:device",
+			ResourceID:   fmt.Sprintf("%s/cb98b74e-ea38-4ae1-adcd-e141d5cf7a2a", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:create:device",
+			ResourceID:   fmt.Sprintf("%s/23be7b0b-044c-480f-9d77-2ef3844e49b0", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:delete:device",
+			ResourceID:   fmt.Sprintf("%s/1291c71c-ae3f-4f3b-b307-51c5636a6814", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:read:userLinkedAccounts",
+			ResourceID:   fmt.Sprintf("%s/5f99b914-f610-4bc6-b4cb-29e439d94b7e", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:delete:userLinkedAccounts",
+			ResourceID:   fmt.Sprintf("%s/cc9a5dad-9ca9-45c4-9b48-2a7ff78802d5", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:create:pairingKey",
+			ResourceID:   fmt.Sprintf("%s/896118f4-f27c-4603-b348-70a602786d8a", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:delete:pairingKey",
+			ResourceID:   fmt.Sprintf("%s/c417b04a-34ec-417d-a52d-d871abc5f411", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:read:pairingKey",
+			ResourceID:   fmt.Sprintf("%s/78a51481-f1e9-426c-a6de-71a05fc7148a", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:read:sessions",
+			ResourceID:   fmt.Sprintf("%s/4be047cf-70b8-4d0b-84c9-33d0fc9c15e8", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:delete:sessions",
+			ResourceID:   fmt.Sprintf("%s/d06d54c1-e54f-4047-97a0-c7d42fa75dbe", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:read:userConsent",
+			ResourceID:   fmt.Sprintf("%s/c5ffe0bf-8936-415b-a40d-a7c3818a3864", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:verify:user",
+			ResourceID:   fmt.Sprintf("%s/7499ab71-a894-488c-9593-de96f74dd0df", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:read:oauthConsent",
+			ResourceID:   fmt.Sprintf("%s/90abdaa3-fa8c-4034-aa36-42d1812c8df7", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope_pingone_api",
+			ResourceName: "PingOne API_p1:update:oauthConsent",
+			ResourceID:   fmt.Sprintf("%s/28281333-293e-4018-82f4-3295db0e0bf8", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_resource_scope_pingone_api_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_resource_scope_pingone_api_test.go
@@ -128,10 +128,5 @@ func TestResourceScopePingOneApiExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_resource_scope_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_resource_scope_test.go
@@ -188,10 +188,5 @@ func TestResourceScopeExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_resource_scope_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_resource_scope_test.go
@@ -1,0 +1,197 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestResourceScopeExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.ResourceScope(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "test_testing",
+			ResourceID:   fmt.Sprintf("%s/4b9ef858-62ce-4bd0-9186-997b8527529d/99bda6e7-f34b-4218-8fb0-221f5414e0db", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "test_oidc",
+			ResourceID:   fmt.Sprintf("%s/4b9ef858-62ce-4bd0-9186-997b8527529d/9f2c9b87-a190-446e-bf6b-d97b7f8b1a70", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "testing_test",
+			ResourceID:   fmt.Sprintf("%s/52afd89f-f3c0-4c78-b896-432c0a07329b/d9935d01-5baa-4843-970a-9df33b60439f", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:read:user",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/089adcde-be64-4e7e-9a5a-dda60ce38a9f", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:read:user:2",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/83d8ee1d-938f-4287-9792-aa808dc0cad9", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:update:user",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/d5bd66de-8044-41c5-aed2-278b6cf47dad", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:update:userMfaEnabled",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/2a8c4a72-b7fb-4093-9e9f-4b2d6040749a", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:validate:userPassword",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/a550ce20-1b72-4bfe-a756-20f21647d1cf", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:reset:userPassword",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/a112f3ef-cfa2-4cde-89d6-965ca88096c5", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:read:userPassword",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/ac9a1304-419b-4786-9113-1b5c5df9db11", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:read:device",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/194a59ec-fae0-462f-ad73-a3fbbdf2430e", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:update:device",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/cb98b74e-ea38-4ae1-adcd-e141d5cf7a2a", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:create:device",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/23be7b0b-044c-480f-9d77-2ef3844e49b0", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:delete:device",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/1291c71c-ae3f-4f3b-b307-51c5636a6814", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:read:userLinkedAccounts",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/5f99b914-f610-4bc6-b4cb-29e439d94b7e", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:delete:userLinkedAccounts",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/cc9a5dad-9ca9-45c4-9b48-2a7ff78802d5", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:create:pairingKey",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/896118f4-f27c-4603-b348-70a602786d8a", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:delete:pairingKey",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/c417b04a-34ec-417d-a52d-d871abc5f411", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:read:pairingKey",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/78a51481-f1e9-426c-a6de-71a05fc7148a", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:read:sessions",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/4be047cf-70b8-4d0b-84c9-33d0fc9c15e8", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:delete:sessions",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/d06d54c1-e54f-4047-97a0-c7d42fa75dbe", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:read:userConsent",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/c5ffe0bf-8936-415b-a40d-a7c3818a3864", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:verify:user",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/7499ab71-a894-488c-9593-de96f74dd0df", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:read:oauthConsent",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/90abdaa3-fa8c-4034-aa36-42d1812c8df7", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "PingOne API_p1:update:oauthConsent",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875/28281333-293e-4018-82f4-3295db0e0bf8", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "openid_profile",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/5a2881ba-affc-4556-a9ff-ad662ea84e89", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "openid_newscope2",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/5f07b021-5f0e-47d0-a62b-1e983bdff753", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "openid_openid",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/6f095311-2cb9-4414-b30f-af8ee5e11e34", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "openid_newscope",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/792fa804-8aae-43c8-bea7-ea2dbbb1ca88", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "openid_email",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/a95eb903-b691-4aa9-91df-8b02d69816df", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "openid_test",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/d4213f0d-e1fc-42db-bcc6-dfad730f7be7", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "openid_phone",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/dad64f0c-187e-4991-a5b3-c4e53a4167e5", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "openid_testing",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/eb7e9feb-6076-4a2e-9e9e-5c9c0a503606", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource_scope",
+			ResourceName: "openid_address",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80/fcd04665-fb97-4943-9c88-427331ebe930", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_resource_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_resource_test.go
@@ -38,10 +38,5 @@ func TestResourceExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_resource_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_resource_test.go
@@ -1,0 +1,47 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestResourceExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.Resource(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_resource",
+			ResourceName: "test",
+			ResourceID:   fmt.Sprintf("%s/4b9ef858-62ce-4bd0-9186-997b8527529d", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource",
+			ResourceName: "testing",
+			ResourceID:   fmt.Sprintf("%s/52afd89f-f3c0-4c78-b896-432c0a07329b", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource",
+			ResourceName: "PingOne API",
+			ResourceID:   fmt.Sprintf("%s/95ed3610-7668-4a17-8334-b3db5ff9a875", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_resource",
+			ResourceName: "openid",
+			ResourceID:   fmt.Sprintf("%s/8c428665-3e68-4f3c-997d-16a97f8cbe80", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_schema_attribute_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_schema_attribute_test.go
@@ -1,0 +1,172 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestSchemaAttributeExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.SchemaAttribute(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_preferredLanguage",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/364bc187-e88f-4853-87f3-64aa13d9a099", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_timezone",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/4d3de681-a822-4633-bc42-8c67f9052fd3", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_lastSignOn",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/6b6992f5-78f6-4a22-97a1-69ba30c591d0", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_title",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/47cdeaa0-5cf0-4964-83b5-b3fe125c092e", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_type",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/acce5383-16ff-4973-8ded-2b19fd9146ed", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_locale",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/b9ff90eb-188e-40b1-9725-92b55e40f1eb", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_enabled",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/022607db-04b7-4d37-a034-798342d32060", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_identityProvider",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/b77ef54a-54c1-4636-83d2-b410ed23aeee", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_lifecycle",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/e3541156-0fe1-4177-aa69-dce02420d8cc", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_createdAt",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/d3221cc9-fb62-42e9-a14c-971a7c7a1e74", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_verifyStatus",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/23a02ffd-9250-401e-8aa5-f8eb71b72c6c", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_nickname",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/87efff27-cdb5-4829-9976-a80ebb4f8ee5", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_mfaEnabled",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/a49c17e2-ce8f-45e5-8e71-d51c8c4d140a", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_id",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/e4bb0b09-3f8d-485e-94ca-20e312471633", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_email",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/0473af5a-1294-4462-8a19-8567e5dccd9c", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_updatedAt",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/8fe405d2-c620-4267-805d-371c2092eb59", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_memberOfGroupIDs",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/d85f4528-54a8-49c7-a643-c098ad28b860", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_address",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/bc10ef33-b7cf-4efd-afc2-44bbd8f572a9", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_externalId",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/985359b0-a6a7-49e3-9079-be770e49b37f", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_photo",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/d991bc82-002d-4872-b544-9f2562452269", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_memberOfGroupNames",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/6a2aa3a6-9926-4070-8827-3bf84f7033fb", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_population",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/fb572f33-8944-4a35-846c-e548dbdeb49f", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_primaryPhone",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/f48f844b-3ba2-45ad-ba3c-de473a12ca4d", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_accountId",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/3658a298-8ce8-446d-ada5-cebb24678506", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_emailVerified",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/c4034a55-f6ae-406e-b3ad-5da3c66d77a2", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_mobilePhone",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/b4a939bf-f60a-41c3-9aad-1482ddf31d32", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_name",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/c8cac0ca-31c6-43d4-a2e6-63b07c936a43", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_account",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/eeed302f-8ca8-4993-aeb0-5d8d08587d8d", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_schema_attribute",
+			ResourceName: "User_username",
+			ResourceID:   fmt.Sprintf("%s/ff3cb03d-4896-4d20-8612-f014c4048d01/77d3f22e-00ca-49d1-98a1-fc0ee48d2542", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_schema_attribute_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_schema_attribute_test.go
@@ -163,10 +163,5 @@ func TestSchemaAttributeExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_sign_on_policy_action.go
+++ b/internal/connector/pingone/sso/resources/pingone_sign_on_policy_action.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"fmt"
 
+	"github.com/patrickcping/pingone-go-sdk-v2/management"
 	"github.com/pingidentity/pingctl/internal/connector"
 	"github.com/pingidentity/pingctl/internal/connector/common"
 	"github.com/pingidentity/pingctl/internal/logger"
@@ -42,11 +43,6 @@ func (r *PingoneSignOnPolicyActionResource) ExportAll() (*[]connector.ImportBloc
 	l.Debug().Msgf("Generating Import Blocks for all %s resources...", r.ResourceType())
 
 	for _, signOnPolicy := range embedded.GetSignOnPolicies() {
-		var (
-			actionId   *string
-			actionIdOk bool
-		)
-
 		signOnPolicyId, signOnPolicyIdOk := signOnPolicy.GetIdOk()
 		signOnPolicyName, signOnPolicyNameOk := signOnPolicy.GetNameOk()
 
@@ -60,32 +56,47 @@ func (r *PingoneSignOnPolicyActionResource) ExportAll() (*[]connector.ImportBloc
 				return nil, err
 			}
 
+			var (
+				actionId     *string
+				actionIdOk   bool
+				actionType   *management.EnumSignOnPolicyType
+				actionTypeOk bool
+			)
+
 			for _, action := range actionEmbedded.GetActions() {
 				switch {
 				case action.SignOnPolicyActionAgreement != nil:
 					actionId, actionIdOk = action.SignOnPolicyActionAgreement.GetIdOk()
+					actionType, actionTypeOk = action.SignOnPolicyActionAgreement.GetTypeOk()
 				case action.SignOnPolicyActionCommon != nil:
 					actionId, actionIdOk = action.SignOnPolicyActionCommon.GetIdOk()
+					actionType, actionTypeOk = action.SignOnPolicyActionCommon.GetTypeOk()
 				case action.SignOnPolicyActionIDFirst != nil:
 					actionId, actionIdOk = action.SignOnPolicyActionIDFirst.GetIdOk()
+					actionType, actionTypeOk = action.SignOnPolicyActionIDFirst.GetTypeOk()
 				case action.SignOnPolicyActionIDP != nil:
 					actionId, actionIdOk = action.SignOnPolicyActionIDP.GetIdOk()
+					actionType, actionTypeOk = action.SignOnPolicyActionIDP.GetTypeOk()
 				case action.SignOnPolicyActionLogin != nil:
 					actionId, actionIdOk = action.SignOnPolicyActionLogin.GetIdOk()
+					actionType, actionTypeOk = action.SignOnPolicyActionLogin.GetTypeOk()
 				case action.SignOnPolicyActionMFA != nil:
 					actionId, actionIdOk = action.SignOnPolicyActionMFA.GetIdOk()
+					actionType, actionTypeOk = action.SignOnPolicyActionMFA.GetTypeOk()
 				case action.SignOnPolicyActionPingIDWinLoginPasswordless != nil:
 					actionId, actionIdOk = action.SignOnPolicyActionPingIDWinLoginPasswordless.GetIdOk()
+					actionType, actionTypeOk = action.SignOnPolicyActionPingIDWinLoginPasswordless.GetTypeOk()
 				case action.SignOnPolicyActionProgressiveProfiling != nil:
 					actionId, actionIdOk = action.SignOnPolicyActionProgressiveProfiling.GetIdOk()
+					actionType, actionTypeOk = action.SignOnPolicyActionProgressiveProfiling.GetTypeOk()
 				default:
 					continue
 				}
 
-				if actionIdOk {
+				if actionIdOk && actionTypeOk {
 					importBlocks = append(importBlocks, connector.ImportBlock{
 						ResourceType: r.ResourceType(),
-						ResourceName: fmt.Sprintf("%s_%s", *signOnPolicyName, *actionId),
+						ResourceName: fmt.Sprintf("%s_%s", *signOnPolicyName, *actionType),
 						ResourceID:   fmt.Sprintf("%s/%s/%s", r.clientInfo.ExportEnvironmentID, *signOnPolicyId, *actionId),
 					})
 				}

--- a/internal/connector/pingone/sso/resources/pingone_sign_on_policy_action_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_sign_on_policy_action_test.go
@@ -1,0 +1,52 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestSignOnPolicyActionExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.SignOnPolicyAction(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_sign_on_policy_action",
+			ResourceName: "testing_LOGIN",
+			ResourceID:   fmt.Sprintf("%s/0667e65d-fcdf-4049-b1b4-9d59392ee8bc/8d6fbf89-6913-403d-ab16-1470af9be22f", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_sign_on_policy_action",
+			ResourceName: "testing_AGREEMENT",
+			ResourceID:   fmt.Sprintf("%s/0667e65d-fcdf-4049-b1b4-9d59392ee8bc/23a73045-e9a7-4557-83c7-8aa3b7c7fb2e", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_sign_on_policy_action",
+			ResourceName: "testing_IDENTITY_PROVIDER",
+			ResourceID:   fmt.Sprintf("%s/0667e65d-fcdf-4049-b1b4-9d59392ee8bc/e975d90d-8355-45a2-94ba-3757734cc64b", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_sign_on_policy_action",
+			ResourceName: "test_LOGIN",
+			ResourceID:   fmt.Sprintf("%s/50cff7e5-7c95-4d1d-9fce-c9cdc7d6f6a3/8114540e-8deb-408b-9307-fa74f00d2683", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_sign_on_policy_action",
+			ResourceName: "Single_Factor_LOGIN",
+			ResourceID:   fmt.Sprintf("%s/b1fdc38d-ea0c-47b1-9d83-c48105bd6806/6cc634a8-a89f-4632-8e84-45b976a18473", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_sign_on_policy_action_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_sign_on_policy_action_test.go
@@ -43,10 +43,5 @@ func TestSignOnPolicyActionExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_sign_on_policy_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_sign_on_policy_test.go
@@ -1,0 +1,42 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestSignOnPolicyExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.SignOnPolicy(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_sign_on_policy",
+			ResourceName: "testing",
+			ResourceID:   fmt.Sprintf("%s/0667e65d-fcdf-4049-b1b4-9d59392ee8bc", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_sign_on_policy",
+			ResourceName: "test",
+			ResourceID:   fmt.Sprintf("%s/50cff7e5-7c95-4d1d-9fce-c9cdc7d6f6a3", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_sign_on_policy",
+			ResourceName: "Single_Factor",
+			ResourceID:   fmt.Sprintf("%s/b1fdc38d-ea0c-47b1-9d83-c48105bd6806", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_sign_on_policy_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_sign_on_policy_test.go
@@ -33,10 +33,5 @@ func TestSignOnPolicyExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_user_group_assignment_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_user_group_assignment_test.go
@@ -1,0 +1,37 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestUserGroupAssignmentExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.UserGroupAssignment(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_user_group_assignment",
+			ResourceName: "test_user2_testing",
+			ResourceID:   fmt.Sprintf("%s/7570f416-5503-4eb0-9fc3-9a485bddd411/b6924f30-73ca-4d3c-964b-90c77adce6a7", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_user_group_assignment",
+			ResourceName: "testing_testing",
+			ResourceID:   fmt.Sprintf("%s/68cb3634-0ed4-4044-85d1-576eb3a55360/b6924f30-73ca-4d3c-964b-90c77adce6a7", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_user_group_assignment_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_user_group_assignment_test.go
@@ -28,10 +28,5 @@ func TestUserGroupAssignmentExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/connector/pingone/sso/resources/pingone_user_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_user_test.go
@@ -1,0 +1,42 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/sso/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestUserExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.User(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_user",
+			ResourceName: "test_user",
+			ResourceID:   fmt.Sprintf("%s/8012b4a3-1874-42d3-803d-76d4a378335c", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_user",
+			ResourceName: "test_user2",
+			ResourceID:   fmt.Sprintf("%s/7570f416-5503-4eb0-9fc3-9a485bddd411", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_user",
+			ResourceName: "testing",
+			ResourceID:   fmt.Sprintf("%s/68cb3634-0ed4-4044-85d1-576eb3a55360", testutils.GetEnvironmentID()),
+		},
+	}
+
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+}

--- a/internal/connector/pingone/sso/resources/pingone_user_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_user_test.go
@@ -33,10 +33,5 @@ func TestUserExport(t *testing.T) {
 		},
 	}
 
-	expectedImportBlocksMap := map[string]connector.ImportBlock{}
-	for _, importBlock := range expectedImportBlocks {
-		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
-	}
-
-	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocksMap)
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
 }

--- a/internal/testutils/helper.go
+++ b/internal/testutils/helper.go
@@ -114,9 +114,9 @@ func ValidateImportBlocks(t *testing.T, resource connector.ExportableResource, e
 
 	// Make sure the importblocks match the expected import blocks
 	for _, importBlock := range *importBlocks {
-		expectedImportBlock := (expectedImportBlocksMap)[importBlock.ResourceName]
+		expectedImportBlock, ok := expectedImportBlocksMap[importBlock.ResourceName]
 
-		if expectedImportBlock.Equals(connector.ImportBlock{}) {
+		if !ok {
 			t.Errorf("No matching expected import block for generated import block:\n%s", importBlock.String())
 			continue
 		}

--- a/internal/testutils/helper.go
+++ b/internal/testutils/helper.go
@@ -100,6 +100,11 @@ func ValidateImportBlocks(t *testing.T, resource connector.ExportableResource, e
 		resourceIDs[importBlock.ResourceID] = true
 	}
 
+	// Check if provided pointer to expected import blocks is nil, and created an empty slice if so.
+	if expectedImportBlocks == nil {
+		expectedImportBlocks = &[]connector.ImportBlock{}
+	}
+
 	expectedImportBlocksMap := map[string]connector.ImportBlock{}
 	for _, importBlock := range *expectedImportBlocks {
 		expectedImportBlocksMap[importBlock.ResourceName] = importBlock

--- a/internal/testutils/helper.go
+++ b/internal/testutils/helper.go
@@ -77,7 +77,7 @@ func GetPingOneSDKClientInfo(t *testing.T) *connector.SDKClientInfo {
 	return sdkClientInfo
 }
 
-func ValidateImportBlocks(t *testing.T, resource connector.ExportableResource, expectedImportBlocksMap *map[string]connector.ImportBlock) {
+func ValidateImportBlocks(t *testing.T, resource connector.ExportableResource, expectedImportBlocks *[]connector.ImportBlock) {
 	t.Helper()
 
 	importBlocks, err := resource.ExportAll()
@@ -100,13 +100,13 @@ func ValidateImportBlocks(t *testing.T, resource connector.ExportableResource, e
 		resourceIDs[importBlock.ResourceID] = true
 	}
 
-	// Check number of export blocks
-	var expectedNumberOfBlocks int
-	if *expectedImportBlocksMap == nil {
-		expectedNumberOfBlocks = 0
-	} else {
-		expectedNumberOfBlocks = len(*expectedImportBlocksMap)
+	expectedImportBlocksMap := map[string]connector.ImportBlock{}
+	for _, importBlock := range *expectedImportBlocks {
+		expectedImportBlocksMap[importBlock.ResourceName] = importBlock
 	}
+
+	// Check number of export blocks
+	expectedNumberOfBlocks := len(expectedImportBlocksMap)
 	actualNumberOfBlocks := len(*importBlocks)
 	if actualNumberOfBlocks != expectedNumberOfBlocks {
 		t.Fatalf("Expected %d import blocks, got %d", expectedNumberOfBlocks, actualNumberOfBlocks)
@@ -114,7 +114,7 @@ func ValidateImportBlocks(t *testing.T, resource connector.ExportableResource, e
 
 	// Make sure the importblocks match the expected import blocks
 	for _, importBlock := range *importBlocks {
-		expectedImportBlock := (*expectedImportBlocksMap)[importBlock.ResourceName]
+		expectedImportBlock := (expectedImportBlocksMap)[importBlock.ResourceName]
 
 		if expectedImportBlock.Equals(connector.ImportBlock{}) {
 			t.Errorf("No matching expected import block for generated import block:\n%s", importBlock.String())

--- a/internal/testutils/helper.go
+++ b/internal/testutils/helper.go
@@ -85,6 +85,21 @@ func ValidateImportBlocks(t *testing.T, resource connector.ExportableResource, e
 		t.Fatalf("Failed to export %s: %s", resource.ResourceType(), err.Error())
 	}
 
+	// Make sure the resource name and id in each import block is unique across all import blocks
+	resourceNames := map[string]bool{}
+	resourceIDs := map[string]bool{}
+	for _, importBlock := range *importBlocks {
+		if resourceNames[importBlock.ResourceName] {
+			t.Errorf("Resource name %s is not unique", importBlock.ResourceName)
+		}
+		resourceNames[importBlock.ResourceName] = true
+
+		if resourceIDs[importBlock.ResourceID] {
+			t.Errorf("Resource ID %s is not unique", importBlock.ResourceID)
+		}
+		resourceIDs[importBlock.ResourceID] = true
+	}
+
 	// Check number of export blocks
 	var expectedNumberOfBlocks int
 	if *expectedImportBlocksMap == nil {
@@ -101,23 +116,13 @@ func ValidateImportBlocks(t *testing.T, resource connector.ExportableResource, e
 	for _, importBlock := range *importBlocks {
 		expectedImportBlock := (*expectedImportBlocksMap)[importBlock.ResourceName]
 
+		if expectedImportBlock.Equals(connector.ImportBlock{}) {
+			t.Errorf("No matching expected import block for generated import block:\n%s", importBlock.String())
+			continue
+		}
+
 		if !importBlock.Equals(expectedImportBlock) {
 			t.Errorf("Expected import block \n%s\n Got import block \n%s", expectedImportBlock.String(), importBlock.String())
 		}
-	}
-
-	// Make sure the resource name and id in each import block is unique across all import blocks
-	resourceNames := map[string]bool{}
-	resourceIDs := map[string]bool{}
-	for _, importBlock := range *importBlocks {
-		if resourceNames[importBlock.ResourceName] {
-			t.Errorf("Resource name %s is not unique", importBlock.ResourceName)
-		}
-		resourceNames[importBlock.ResourceName] = true
-
-		if resourceIDs[importBlock.ResourceID] {
-			t.Errorf("Resource ID %s is not unique", importBlock.ResourceID)
-		}
-		resourceIDs[importBlock.ResourceID] = true
 	}
 }


### PR DESCRIPTION
- Add SSO resource unit testing
- Update pingone_application_flow_policy.go to use the policy name instead of ID for ResourceName in the ImportBlock.
- Update pingone_application_resource_grant.go to use the resource name instead of ID for ResourceName in the ImportBlock.
- Update pingone_application_role_assignment.go to use an index number in ResourceName for the ImportBlock to avoid ResourceName duplication.
- Update pingone_application_sign_on_policy_assignment.go to use the sign on policy name instead of ID for ResourceName in the ImportBlock.
- Update pingone_group_role_assignment.go to use the role name instead of ID for ResourceName in the Importblock, as well as an index number to avoid ResourceName duplication.
- Update pingone_sign_on_action.go to use the action type instead of ID for ResourceName in the ImportBlock.
- Update helper test function ValidateImportBlocks to check for resource name and id duplication first after rework to use import block map instead of list for expected import blocks.
- Update helper test function to check if the retrieved expected import block is empty, meaning there was no match with the currently compared generated import block.