### PR TITLE
PDI-1642: Update PingCTL with Internal Feedback

### DIFF
--- a/cmd/platform/export.go
+++ b/cmd/platform/export.go
@@ -96,7 +96,7 @@ func NewExportCommand() *cobra.Command {
 					Message: fmt.Sprintf("Failed to find or validate export output directory %q", outputDir),
 					Result:  output.ENUMCOMMANDOUTPUTRESULT_FAILURE,
 				})
-				return err
+				return fmt.Errorf("failed to find or validate export output directory %q. Err: %s", outputDir, err.Error())
 			}
 
 			// Find the env ID to export. Default to worker env id if not provided by user.

--- a/internal/connector/common/common_utils.go
+++ b/internal/connector/common/common_utils.go
@@ -13,17 +13,34 @@ import (
 func WriteFiles(exportableResources []connector.ExportableResource, format, outputDir string, service string, overwriteExport bool) error {
 	l := logger.Get()
 
-	hclImportBlockTemplate, err := template.New("HCLImportBlock").Parse(connector.HCLImportBlockTemplate)
-	if err != nil {
-		return fmt.Errorf("failed to parse HCL import block template. err: %s", err.Error())
+	// Check if the output directory is empty
+	// If not, default behavior is to exit and not overwrite.
+	// This can be changed with the --overwrite export parameter
+	if !overwriteExport {
+		dirEntries, err := os.ReadDir(outputDir)
+		if err != nil {
+			return fmt.Errorf("failed to read export directory %q. err: %s", outputDir, err.Error())
+		}
+
+		if len(dirEntries) > 0 {
+			return fmt.Errorf("export directory %q is not empty. Use --overwrite to overwrite existing export data", outputDir)
+		}
 	}
 
-	// Make subdirectory for exported service
+	// Make subdirectory for exported service if there are resources to export
 	if len(exportableResources) > 0 {
 		err := os.MkdirAll(filepath.Join(outputDir, service), os.ModePerm)
 		if err != nil {
 			return fmt.Errorf("failed to create %s export subfolder. err: %s", service, err.Error())
 		}
+	} else {
+		return nil
+	}
+
+	// Parse the HCL import block template
+	hclImportBlockTemplate, err := template.New("HCLImportBlock").Parse(connector.HCLImportBlockTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to parse HCL import block template. err: %s", err.Error())
 	}
 
 	for _, exportableResource := range exportableResources {


### PR DESCRIPTION
- Check entire export directory. If there is anything present, abort the export of all services. This avoids mismatching environment exports over multiple export commands from the customer.
- Small error message update for export.go.