### PR TITLE
PDI-1642: Update PingCTL with Internal Feedback

### DIFF
--- a/cmd/platform/export.go
+++ b/cmd/platform/export.go
@@ -99,6 +99,20 @@ func NewExportCommand() *cobra.Command {
 				return fmt.Errorf("failed to find or validate export output directory %q. Err: %s", outputDir, err.Error())
 			}
 
+			// Check if the output directory is empty
+			// If not, default behavior is to exit and not overwrite.
+			// This can be changed with the --overwrite export parameter
+			if !overwriteExport {
+				dirEntries, err := os.ReadDir(outputDir)
+				if err != nil {
+					return fmt.Errorf("failed to read contents of export directory %q. err: %s", outputDir, err.Error())
+				}
+
+				if len(dirEntries) > 0 {
+					return fmt.Errorf("export directory %q is not empty. Use --overwrite to overwrite existing export data", outputDir)
+				}
+			}
+
 			// Find the env ID to export. Default to worker env id if not provided by user.
 			exportEnvID := viper.GetString(pingoneExportEnvironmentIdParamConfigKey)
 			if exportEnvID == "" {

--- a/internal/connector/common/common_utils.go
+++ b/internal/connector/common/common_utils.go
@@ -13,20 +13,6 @@ import (
 func WriteFiles(exportableResources []connector.ExportableResource, format, outputDir string, service string, overwriteExport bool) error {
 	l := logger.Get()
 
-	// Check if the output directory is empty
-	// If not, default behavior is to exit and not overwrite.
-	// This can be changed with the --overwrite export parameter
-	if !overwriteExport {
-		dirEntries, err := os.ReadDir(outputDir)
-		if err != nil {
-			return fmt.Errorf("failed to read export directory %q. err: %s", outputDir, err.Error())
-		}
-
-		if len(dirEntries) > 0 {
-			return fmt.Errorf("export directory %q is not empty. Use --overwrite to overwrite existing export data", outputDir)
-		}
-	}
-
 	// Make subdirectory for exported service if there are resources to export
 	if len(exportableResources) > 0 {
 		err := os.MkdirAll(filepath.Join(outputDir, service), os.ModePerm)


### PR DESCRIPTION
- Fix export directory check to be in export.go instead of WriteFiles(). This avoids a bug where an initially empty export directory fails on the second call to WriteFiles if multiple services are exported.