### PR TITLE
PDI-1642: Update PingCTL with Internal Feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@
 .vscode/*
 go.work
 go.work.sum
-gen
+export
 vendor
 env*.sh

--- a/internal/connector/common/resources_common.go
+++ b/internal/connector/common/resources_common.go
@@ -18,9 +18,9 @@ func HandleClientResponse(response *http.Response, err error, apiFunctionName st
 	}
 
 	if response.StatusCode == 404 {
-		l.Error().Msgf("%s Request was not successful. Resources %s not found", apiFunctionName, resourceType)
+		l.Error().Msgf("%s Request was not successful. Resource(s) %s not found", apiFunctionName, resourceType)
 		l.Error().Err(err).Msgf("%s Response Code: %s\nResponse Body: %s", apiFunctionName, response.Status, response.Body)
-		return fmt.Errorf("failed to fetch %s resources via %s()", resourceType, apiFunctionName)
+		return fmt.Errorf("failed to fetch %s resource(s) via %s()", resourceType, apiFunctionName)
 	}
 
 	if response.StatusCode >= 300 {

--- a/internal/connector/pingone/platform/resources/pingone_branding_settings.go
+++ b/internal/connector/pingone/platform/resources/pingone_branding_settings.go
@@ -27,9 +27,20 @@ func (r *PingoneBrandingSettingsResource) ExportAll() (*[]connector.ImportBlock,
 
 	l.Debug().Msgf("Fetching all %s resources...", r.ResourceType())
 
+	_, response, err := r.clientInfo.ApiClient.ManagementAPIClient.BrandingSettingsApi.ReadBrandingSettings(r.clientInfo.Context, r.clientInfo.ExportEnvironmentID).Execute()
+	err = common.HandleClientResponse(response, err, "ReadBrandingSettings", r.ResourceType())
+	if err != nil {
+		return nil, err
+	}
+
 	importBlocks := []connector.ImportBlock{}
 
 	l.Debug().Msgf("Generating Import Blocks for all %s resources...", r.ResourceType())
+
+	if response.StatusCode == 204 {
+		l.Debug().Msgf("No exportable %s resource found", r.ResourceType())
+		return &importBlocks, nil
+	}
 
 	commentData := map[string]string{
 		"Resource Type":         r.ResourceType(),

--- a/internal/connector/pingone/platform/resources/pingone_branding_theme_default_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_branding_theme_default_test.go
@@ -17,7 +17,7 @@ func TestBrandingThemeDefaultExport(t *testing.T) {
 	expectedImportBlocks := []connector.ImportBlock{
 		{
 			ResourceType: "pingone_branding_theme_default",
-			ResourceName: "active_theme",
+			ResourceName: "test_slate_2_default_theme",
 			ResourceID:   testutils.GetEnvironmentID(),
 		},
 	}

--- a/internal/connector/pingone/platform/resources/pingone_forms_recaptcha_v2.go
+++ b/internal/connector/pingone/platform/resources/pingone_forms_recaptcha_v2.go
@@ -27,9 +27,22 @@ func (r *PingoneFormRecaptchaV2Resource) ExportAll() (*[]connector.ImportBlock, 
 
 	l.Debug().Msgf("Fetching all %s resources...", r.ResourceType())
 
-	importBlocks := []connector.ImportBlock{}
+	// Fetch FormRecaptchaV2 Resource from API.
+	// If response is 204 No Content, then return empty import blocks.
+	_, response, err := r.clientInfo.ApiClient.ManagementAPIClient.RecaptchaConfigurationApi.ReadRecaptchaConfiguration(r.clientInfo.Context, r.clientInfo.ExportEnvironmentID).Execute()
+	err = common.HandleClientResponse(response, err, "ReadRecaptchaConfiguration", r.ResourceType())
+	if err != nil {
+		return nil, err
+	}
 
 	l.Debug().Msgf("Generating Import Blocks for all %s resources...", r.ResourceType())
+
+	importBlocks := []connector.ImportBlock{}
+
+	if response.StatusCode == 204 {
+		l.Debug().Msgf("No exportable %s resource found", r.ResourceType())
+		return &importBlocks, nil
+	}
 
 	commentData := map[string]string{
 		"Resource Type":         r.ResourceType(),

--- a/internal/connector/pingone/platform/resources/pingone_gateway_credential_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_gateway_credential_test.go
@@ -51,6 +51,11 @@ func TestGatewayCredentialExport(t *testing.T) {
 			ResourceName: "TestGateway_credential_3",
 			ResourceID:   fmt.Sprintf("%s/bc37814f-b3a9-4149-b880-0ed457bbb5c5/ed648842-d109-4a40-97ba-ef4f8ce8eabe", testutils.GetEnvironmentID()),
 		},
+		{
+			ResourceType: "pingone_gateway_credential",
+			ResourceName: "another connection for testing_credential_1",
+			ResourceID:   fmt.Sprintf("%s/8773b833-ade0-4883-9cad-05fe82b23135/98f9946c-3a78-4b4b-8645-a425f89c7ab5", testutils.GetEnvironmentID()),
+		},
 	}
 
 	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)

--- a/internal/connector/pingone/platform/resources/pingone_gateway_role_assignment_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_gateway_role_assignment_test.go
@@ -36,6 +36,16 @@ func TestGatewayRoleAssignmentExport(t *testing.T) {
 			ResourceName: "Local Test_Environment Admin",
 			ResourceID:   fmt.Sprintf("%s/5cd3f6b7-35f0-4873-ac64-f32118bf3102/393d4c4e-6642-432d-bc11-1638948d6dd2", testutils.GetEnvironmentID()),
 		},
+		{
+			ResourceType: "pingone_gateway_role_assignment",
+			ResourceName: "another connection for testing_Identity Data Admin",
+			ResourceID:   fmt.Sprintf("%s/8773b833-ade0-4883-9cad-05fe82b23135/239579d0-fc0b-4b50-ba03-dfe80e2bb6d0", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_gateway_role_assignment",
+			ResourceName: "another connection for testing_Environment Admin",
+			ResourceID:   fmt.Sprintf("%s/8773b833-ade0-4883-9cad-05fe82b23135/07ed5801-4d44-4578-9d2f-c6ef6d537e83", testutils.GetEnvironmentID()),
+		},
 	}
 
 	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)

--- a/internal/connector/pingone/platform/resources/pingone_gateway_test.go
+++ b/internal/connector/pingone/platform/resources/pingone_gateway_test.go
@@ -41,6 +41,11 @@ func TestGatewayExport(t *testing.T) {
 			ResourceName: "TestGateway",
 			ResourceID:   fmt.Sprintf("%s/bc37814f-b3a9-4149-b880-0ed457bbb5c5", testutils.GetEnvironmentID()),
 		},
+		{
+			ResourceType: "pingone_gateway",
+			ResourceName: "another connection for testing",
+			ResourceID:   fmt.Sprintf("%s/8773b833-ade0-4883-9cad-05fe82b23135", testutils.GetEnvironmentID()),
+		},
 	}
 
 	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)

--- a/internal/connector/pingone/platform/resources/pingone_notification_settings.go
+++ b/internal/connector/pingone/platform/resources/pingone_notification_settings.go
@@ -27,9 +27,20 @@ func (r *PingoneNotificationSettingsResource) ExportAll() (*[]connector.ImportBl
 
 	l.Debug().Msgf("Fetching all %s resources...", r.ResourceType())
 
+	_, response, err := r.clientInfo.ApiClient.ManagementAPIClient.NotificationsSettingsApi.ReadNotificationsSettings(r.clientInfo.Context, r.clientInfo.ExportEnvironmentID).Execute()
+	err = common.HandleClientResponse(response, err, "ReadNotificationsSettings", r.ResourceType())
+	if err != nil {
+		return nil, err
+	}
+
 	importBlocks := []connector.ImportBlock{}
 
 	l.Debug().Msgf("Generating Import Blocks for all %s resources...", r.ResourceType())
+
+	if response.StatusCode == 204 {
+		l.Debug().Msgf("No exportable %s resource found", r.ResourceType())
+		return &importBlocks, nil
+	}
 
 	commentData := map[string]string{
 		"Resource Type":         r.ResourceType(),

--- a/internal/connector/pingone/platform/resources/pingone_notification_settings_email.go
+++ b/internal/connector/pingone/platform/resources/pingone_notification_settings_email.go
@@ -27,9 +27,20 @@ func (r *PingoneNotificationSettingsEmailResource) ExportAll() (*[]connector.Imp
 
 	l.Debug().Msgf("Fetching all %s resources...", r.ResourceType())
 
+	_, response, err := r.clientInfo.ApiClient.ManagementAPIClient.NotificationsSettingsSMTPApi.ReadEmailNotificationsSettings(r.clientInfo.Context, r.clientInfo.ExportEnvironmentID).Execute()
+	err = common.HandleClientResponse(response, err, "ReadEmailNotificationsSettings", r.ResourceType())
+	if err != nil {
+		return nil, err
+	}
+
 	importBlocks := []connector.ImportBlock{}
 
 	l.Debug().Msgf("Generating Import Blocks for all %s resources...", r.ResourceType())
+
+	if response.StatusCode == 204 {
+		l.Debug().Msgf("No exportable %s resource found", r.ResourceType())
+		return &importBlocks, nil
+	}
 
 	commentData := map[string]string{
 		"Resource Type":         r.ResourceType(),

--- a/internal/connector/pingone/sso/resources/pingone_population_default_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_population_default_test.go
@@ -17,7 +17,7 @@ func TestPopulationDefaultExport(t *testing.T) {
 	expectedImportBlocks := []connector.ImportBlock{
 		{
 			ResourceType: "pingone_population_default",
-			ResourceName: "population_default",
+			ResourceName: "Default_population_default",
 			ResourceID:   testutils.GetEnvironmentID(),
 		},
 	}


### PR DESCRIPTION
- Update export.go to create outputDir if directory does not exist. Warn user this has happened.
- Update export.go to default outputDir to $(pwd)/export, since export requires an empty directory. Include this new default export directory in .gitignore.
- Update export.go to allow main.go to handle error messaging, minimizing repeated error logging to console.
- Update export of resources that only require the env id on import to check if resource exists before ImportBlock creation.
- Update testing to handle new gateway added to test environment, and update tests for some modified resources from above changes.