### PR TITLE
PDI-1667: Implement Changes for CLI Version alpha.2

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -6,10 +6,9 @@ import (
 
 func NewAuthCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "auth",
-		//TODO more fleshed-out descriptions
-		Short: "Authenticate with Ping",
-		Long:  "Authenticate with Ping",
+		Use:   "auth",
+		Short: "Authenticate the CLI with configured Ping connections",
+		Long:  "Authenticate the CLI with configured Ping connections",
 	}
 
 	cmd.AddCommand(NewLoginCommand(), NewLogoutCommand())

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -6,10 +6,9 @@ import (
 
 func NewLoginCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "login",
-		//TODO more fleshed-out descriptions
-		Short: "Login with Ping",
-		Long:  "Login with Ping",
+		Use:   "login",
+		Short: "Login user to the CLI",
+		Long:  "Login user to the CLI",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// authConnectors := []connector.Authenticatable{}
 			return nil

--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -6,10 +6,9 @@ import (
 
 func NewLogoutCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "logout",
-		//TODO more fleshed-out descriptions
-		Short: "Logout with Ping",
-		Long:  "Logout with Ping",
+		Use:   "logout",
+		Short: "Logout user from the CLI",
+		Long:  "Logout user from the CLI",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// authConnectors := []connector.Authenticatable{}
 			return nil

--- a/cmd/platform/platform.go
+++ b/cmd/platform/platform.go
@@ -7,10 +7,9 @@ import (
 
 func NewPlatformCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "platform",
-		//TODO add command short and long description
-		Short: "",
-		Long:  ``,
+		Use:   "platform",
+		Short: "Provides details and interactions with the connected Ping Platform.",
+		Long:  `Provides details and interactions with the connected Ping Platform.`,
 	}
 
 	cmd.AddCommand(NewExportCommand())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,11 +39,11 @@ var (
 // rootCmd represents the base command when called without any subcommands
 func NewRootCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "pingctl",
-		Version: "v0.0.1",
-		//TODO add command short and long description
-		Short: "",
-		Long:  ``,
+		Use:           "pingctl",
+		Version:       "v2.0.0-alpha.2",
+		Short:         "A CLI tool for managing Ping Identity products.",
+		Long:          `A CLI tool for managing Ping Identity products.`,
+		SilenceErrors: true, // Upon error in RunE method, let output package in main.go handle error output
 	}
 
 	cmd.AddCommand(

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -134,12 +134,6 @@ func formatJson(cmd *cobra.Command, output CommandOutput) {
 	cmd.Println(string(jsonOut))
 
 	switch output.Result {
-	case ENUMCOMMANDOUTPUTRESULT_SUCCESS:
-		fallthrough
-	case ENUMCOMMANDOUTPUTRESULT_NIL:
-		fallthrough
-	case ENUMCOMMANDOUTPUTRESULT_NOACTION_OK:
-		l.Info().Msgf(string(jsonOut))
 	case ENUMCOMMANDOUTPUTRESULT_NOACTION_WARN:
 		l.Warn().Msgf(string(jsonOut))
 	case ENUMCOMMANDOUTPUTRESULT_FAILURE:
@@ -152,7 +146,7 @@ func formatJson(cmd *cobra.Command, output CommandOutput) {
 		if output.Fatal != nil {
 			l.Fatal().Msgf(output.Fatal.Error())
 		}
-	default:
+	default: //ENUMCOMMANDOUTPUTRESULT_SUCCESS, ENUMCOMMANDOUTPUTRESULT_NIL, ENUMCOMMANDOUTPUTRESULT_NOACTION_OK
 		l.Info().Msgf(string(jsonOut))
 	}
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -24,7 +24,6 @@ type CommandOutputResult string
 type CommandOutput struct {
 	Fields  map[string]interface{}
 	Message string
-	Warn    string
 	Error   error
 	Fatal   error
 	Result  CommandOutputResult
@@ -60,9 +59,8 @@ func Format(cmd *cobra.Command, output CommandOutput) {
 		formatJson(cmd, output)
 	default:
 		formatText(cmd, CommandOutput{
-			Message: "",
-			Warn:    fmt.Sprintf("Output format %q is not recognized. Defaulting to \"text\" output", outputFormat),
-			Result:  ENUMCOMMANDOUTPUTRESULT_NIL,
+			Message: fmt.Sprintf("Output format %q is not recognized. Defaulting to \"text\" output", outputFormat),
+			Result:  ENUMCOMMANDOUTPUTRESULT_NOACTION_WARN,
 		})
 		formatText(cmd, output)
 	}
@@ -109,12 +107,6 @@ func formatText(cmd *cobra.Command, output CommandOutput) {
 		}
 	}
 
-	// Inform the user of a warning and log the warning
-	if output.Warn != "" {
-		cmd.Println(yellow("Warn: %s", output.Warn))
-		l.Warn().Msgf(output.Warn)
-	}
-
 	// Inform the user of an error and log the error
 	if output.Error != nil {
 		cmd.Println(red("Error: %s", output.Error.Error()))
@@ -141,21 +133,27 @@ func formatJson(cmd *cobra.Command, output CommandOutput) {
 	// Output the JSON as uncolored string
 	cmd.Println(string(jsonOut))
 
-	// Log the serialized JSON as info.
-	l.Info().Msgf(string(jsonOut))
+	switch output.Result {
+	case ENUMCOMMANDOUTPUTRESULT_SUCCESS:
+		fallthrough
+	case ENUMCOMMANDOUTPUTRESULT_NIL:
+		fallthrough
+	case ENUMCOMMANDOUTPUTRESULT_NOACTION_OK:
+		l.Info().Msgf(string(jsonOut))
+	case ENUMCOMMANDOUTPUTRESULT_NOACTION_WARN:
+		l.Warn().Msgf(string(jsonOut))
+	case ENUMCOMMANDOUTPUTRESULT_FAILURE:
+		// Log the error if exists
+		if output.Error != nil {
+			l.Error().Msgf(output.Error.Error())
+		}
 
-	// Log the warning if exists
-	if output.Warn != "" {
-		l.Warn().Msgf(output.Warn)
+		// Log the fatal error if exists. This exits the program.
+		if output.Fatal != nil {
+			l.Fatal().Msgf(output.Fatal.Error())
+		}
+	default:
+		l.Info().Msgf(string(jsonOut))
 	}
 
-	// Log the error if exists
-	if output.Error != nil {
-		l.Error().Msgf(output.Error.Error())
-	}
-
-	// Log the fatal error if exists. This exits the program.
-	if output.Fatal != nil {
-		l.Fatal().Msgf(output.Fatal.Error())
-	}
 }


### PR DESCRIPTION
- Add desciptions to each cobra command in the command tree.
- Remove "Warn" field from output command struct, in favor of using "Result" and "Message" fields to handle output coloring.
- Add warning for unspecified export environment ID.
- Add API client configuration values to error message upon client initialization failure. Include worker app secret only in TRACE or DEBUG mode.
- Update CLI version to match github release version
- Upon error in any RunE method, silence cobra error output in favor of allowing the output package in main.go to handle error output.
- Lower severity of failed pingone application secret export to warning, and continue exporting the rest of the secret resources.