### PR TITLE
PDI-1810: Import block HCL generation for PingOne MFA

### DIFF
--- a/cmd/platform/custom_types.go
+++ b/cmd/platform/custom_types.go
@@ -11,6 +11,7 @@ import (
 const (
 	serviceEnumPlatform string = "pingone-platform"
 	serviceEnumSSO      string = "pingone-sso"
+	serviceEnumMFA      string = "pingone-mfa"
 )
 
 type MultiService struct {
@@ -36,6 +37,7 @@ func NewMultiService() *MultiService {
 		services: &map[string]bool{
 			serviceEnumPlatform: true,
 			serviceEnumSSO:      true,
+			serviceEnumMFA:      true,
 		},
 		isDefaultServices: true,
 	}
@@ -65,8 +67,10 @@ func (s *MultiService) Set(service string) error {
 		(*s.services)[serviceEnumPlatform] = true
 	case serviceEnumSSO:
 		(*s.services)[serviceEnumSSO] = true
+	case serviceEnumMFA:
+		(*s.services)[serviceEnumMFA] = true
 	default:
-		return fmt.Errorf("unrecognized service %q. Must be one of: %q, %q", service, serviceEnumPlatform, serviceEnumSSO)
+		return fmt.Errorf("unrecognized service %q. Must be one of: %q, %q, %q", service, serviceEnumPlatform, serviceEnumSSO, serviceEnumMFA)
 	}
 	return nil
 }

--- a/cmd/platform/export.go
+++ b/cmd/platform/export.go
@@ -9,6 +9,7 @@ import (
 
 	sdk "github.com/patrickcping/pingone-go-sdk-v2/pingone"
 	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/mfa"
 	"github.com/pingidentity/pingctl/internal/connector/pingone/platform"
 	"github.com/pingidentity/pingctl/internal/connector/pingone/sso"
 	"github.com/pingidentity/pingctl/internal/logger"
@@ -155,6 +156,8 @@ func NewExportCommand() *cobra.Command {
 					exportableConnectors = append(exportableConnectors, platform.PlatformConnector(cmd.Context(), apiClient, &apiClientId, exportEnvID))
 				case serviceEnumSSO:
 					exportableConnectors = append(exportableConnectors, sso.SSOConnector(cmd.Context(), apiClient, &apiClientId, exportEnvID))
+				case serviceEnumMFA:
+					exportableConnectors = append(exportableConnectors, mfa.MFAConnector(cmd.Context(), apiClient, &apiClientId, exportEnvID))
 					// default:
 					// This unrecognized service condition is handled by cobra with the custom type MultiService
 				}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golangci/golangci-lint v1.55.2
 	github.com/patrickcping/pingone-go-sdk-v2 v0.11.8
 	github.com/patrickcping/pingone-go-sdk-v2/management v0.38.0
+	github.com/patrickcping/pingone-go-sdk-v2/mfa v0.18.3
 	github.com/pavius/impi v0.0.3
 	github.com/rs/zerolog v1.32.0
 	github.com/spf13/cobra v1.8.0
@@ -126,7 +127,6 @@ require (
 	github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.3.1 // indirect
 	github.com/patrickcping/pingone-go-sdk-v2/authorize v0.4.1 // indirect
 	github.com/patrickcping/pingone-go-sdk-v2/credentials v0.6.2 // indirect
-	github.com/patrickcping/pingone-go-sdk-v2/mfa v0.18.3 // indirect
 	github.com/patrickcping/pingone-go-sdk-v2/risk v0.14.1 // indirect
 	github.com/patrickcping/pingone-go-sdk-v2/verify v0.4.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.0 // indirect

--- a/internal/connector/pingone/mfa/pingone_mfa_connector.go
+++ b/internal/connector/pingone/mfa/pingone_mfa_connector.go
@@ -44,6 +44,7 @@ func (c *PingoneMFAConnector) Export(format, outputDir string, overwriteExport b
 	exportableResources := []connector.ExportableResource{
 		resources.MFAApplicationPushCredential(&c.clientInfo),
 		resources.MFAFido2Policy(&c.clientInfo),
+		resources.MFAPolicy(&c.clientInfo),
 	}
 
 	return common.WriteFiles(exportableResources, format, outputDir, c.ConnectorServiceName(), overwriteExport)

--- a/internal/connector/pingone/mfa/pingone_mfa_connector.go
+++ b/internal/connector/pingone/mfa/pingone_mfa_connector.go
@@ -45,6 +45,7 @@ func (c *PingoneMFAConnector) Export(format, outputDir string, overwriteExport b
 		resources.MFAApplicationPushCredential(&c.clientInfo),
 		resources.MFAFido2Policy(&c.clientInfo),
 		resources.MFAPolicy(&c.clientInfo),
+		resources.MFASettings(&c.clientInfo),
 	}
 
 	return common.WriteFiles(exportableResources, format, outputDir, c.ConnectorServiceName(), overwriteExport)

--- a/internal/connector/pingone/mfa/pingone_mfa_connector.go
+++ b/internal/connector/pingone/mfa/pingone_mfa_connector.go
@@ -1,0 +1,61 @@
+package mfa
+
+import (
+	"context"
+
+	sdk "github.com/patrickcping/pingone-go-sdk-v2/pingone"
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/common"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/mfa/resources"
+	"github.com/pingidentity/pingctl/internal/logger"
+)
+
+const (
+	serviceName = "pingone-mfa"
+)
+
+// Verify that the connector satisfies the expected interfaces
+var (
+	_ connector.Exportable      = &PingoneMFAConnector{}
+	_ connector.Authenticatable = &PingoneMFAConnector{}
+)
+
+type PingoneMFAConnector struct {
+	clientInfo connector.SDKClientInfo
+}
+
+// Utility method for creating a PingoneMFAConnector
+func MFAConnector(ctx context.Context, apiClient *sdk.Client, apiClientId *string, exportEnvironmentID string) *PingoneMFAConnector {
+	return &PingoneMFAConnector{
+		clientInfo: connector.SDKClientInfo{
+			Context:             ctx,
+			ApiClient:           apiClient,
+			ApiClientId:         apiClientId,
+			ExportEnvironmentID: exportEnvironmentID,
+		},
+	}
+}
+
+func (c *PingoneMFAConnector) Export(format, outputDir string, overwriteExport bool) error {
+	l := logger.Get()
+
+	l.Debug().Msgf("Exporting all PingOne MFA Resources...")
+
+	exportableResources := []connector.ExportableResource{
+		resources.MFAApplicationPushCredential(&c.clientInfo),
+	}
+
+	return common.WriteFiles(exportableResources, format, outputDir, c.ConnectorServiceName(), overwriteExport)
+}
+
+func (c *PingoneMFAConnector) ConnectorServiceName() string {
+	return serviceName
+}
+
+func (c *PingoneMFAConnector) Login() error {
+	return nil
+}
+
+func (c *PingoneMFAConnector) Logout() error {
+	return nil
+}

--- a/internal/connector/pingone/mfa/pingone_mfa_connector.go
+++ b/internal/connector/pingone/mfa/pingone_mfa_connector.go
@@ -43,6 +43,7 @@ func (c *PingoneMFAConnector) Export(format, outputDir string, overwriteExport b
 
 	exportableResources := []connector.ExportableResource{
 		resources.MFAApplicationPushCredential(&c.clientInfo),
+		resources.MFAFido2Policy(&c.clientInfo),
 	}
 
 	return common.WriteFiles(exportableResources, format, outputDir, c.ConnectorServiceName(), overwriteExport)

--- a/internal/connector/pingone/mfa/resources/pingone_mfa_application_push_credential.go
+++ b/internal/connector/pingone/mfa/resources/pingone_mfa_application_push_credential.go
@@ -79,8 +79,10 @@ func (r *PingoneMFAApplicationPushCredentialResource) ExportAll() (*[]connector.
 				if mfaPushCredentialResponseTypeOk && mfaPushCredentialResponseIdOk {
 					commentData := map[string]string{
 						"Resource Type":            r.ResourceType(),
+						"Application Name":         *appName,
 						"MFA Push Credential Type": string(*mfaPushCredentialResponseType),
 						"Export Environment ID":    r.clientInfo.ExportEnvironmentID,
+						"Application ID":           *appId,
 						"MFA Push Credential ID":   *mfaPushCredentialResponseId,
 					}
 

--- a/internal/connector/pingone/mfa/resources/pingone_mfa_application_push_credential.go
+++ b/internal/connector/pingone/mfa/resources/pingone_mfa_application_push_credential.go
@@ -1,0 +1,103 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/common"
+	"github.com/pingidentity/pingctl/internal/logger"
+)
+
+// Verify that the resource satisfies the exportable resource interface
+var (
+	_ connector.ExportableResource = &PingoneMFAApplicationPushCredentialResource{}
+)
+
+type PingoneMFAApplicationPushCredentialResource struct {
+	clientInfo *connector.SDKClientInfo
+}
+
+// Utility method for creating a PingoneMFAApplicationPushCredentialResource
+func MFAApplicationPushCredential(clientInfo *connector.SDKClientInfo) *PingoneMFAApplicationPushCredentialResource {
+	return &PingoneMFAApplicationPushCredentialResource{
+		clientInfo: clientInfo,
+	}
+}
+
+func (r *PingoneMFAApplicationPushCredentialResource) ExportAll() (*[]connector.ImportBlock, error) {
+	l := logger.Get()
+
+	l.Debug().Msgf("Fetching all %s resources...", r.ResourceType())
+
+	// Fetch all pingone_application resources that could have pingone_mfa_application_push_credentials
+	apiExecuteApplicationsFunc := r.clientInfo.ApiClient.ManagementAPIClient.ApplicationsApi.ReadAllApplications(r.clientInfo.Context, r.clientInfo.ExportEnvironmentID).Execute
+	apiApplicationFunctionName := "ReadAllApplications"
+
+	embedded, err := common.GetManagementEmbedded(apiExecuteApplicationsFunc, apiApplicationFunctionName, r.ResourceType())
+	if err != nil {
+		return nil, err
+	}
+
+	importBlocks := []connector.ImportBlock{}
+
+	l.Debug().Msgf("Generating Import Blocks for all %s resources...", r.ResourceType())
+
+	for _, app := range embedded.GetApplications() {
+		var (
+			appId     *string
+			appIdOk   bool
+			appName   *string
+			appNameOk bool
+		)
+
+		switch {
+		case app.ApplicationOIDC != nil:
+			appId, appIdOk = app.ApplicationOIDC.GetIdOk()
+			appName, appNameOk = app.ApplicationOIDC.GetNameOk()
+		case app.ApplicationSAML != nil:
+			appId, appIdOk = app.ApplicationSAML.GetIdOk()
+			appName, appNameOk = app.ApplicationSAML.GetNameOk()
+		case app.ApplicationExternalLink != nil:
+			appId, appIdOk = app.ApplicationExternalLink.GetIdOk()
+			appName, appNameOk = app.ApplicationExternalLink.GetNameOk()
+		}
+
+		if appIdOk && appNameOk {
+			// Fetch all pingone_mfa_application_push_credentials for each application
+			apiExecuteFunc := r.clientInfo.ApiClient.MFAAPIClient.ApplicationsApplicationMFAPushCredentialsApi.ReadAllMFAPushCredentials(r.clientInfo.Context, r.clientInfo.ExportEnvironmentID, *appId).Execute
+			apiFunctionName := "ReadAllMFAPushCredentials"
+
+			embedded, err := common.GetMFAEmbedded(apiExecuteFunc, apiFunctionName, r.ResourceType())
+			if err != nil {
+				return nil, err
+			}
+
+			for _, mfaPushCredentialResponse := range embedded.GetPushCredentials() {
+				mfaPushCredentialResponseType, mfaPushCredentialResponseTypeOk := mfaPushCredentialResponse.GetTypeOk()
+				mfaPushCredentialResponseId, mfaPushCredentialResponseIdOk := mfaPushCredentialResponse.GetIdOk()
+
+				if mfaPushCredentialResponseTypeOk && mfaPushCredentialResponseIdOk {
+					commentData := map[string]string{
+						"Resource Type":            r.ResourceType(),
+						"MFA Push Credential Type": string(*mfaPushCredentialResponseType),
+						"Export Environment ID":    r.clientInfo.ExportEnvironmentID,
+						"MFA Push Credential ID":   *mfaPushCredentialResponseId,
+					}
+
+					importBlocks = append(importBlocks, connector.ImportBlock{
+						ResourceType:       r.ResourceType(),
+						ResourceName:       fmt.Sprintf("%s_%s", *appName, *mfaPushCredentialResponseType),
+						ResourceID:         fmt.Sprintf("%s/%s/%s", r.clientInfo.ExportEnvironmentID, *appId, *mfaPushCredentialResponseId),
+						CommentInformation: common.GenerateCommentInformation(commentData),
+					})
+				}
+			}
+		}
+	}
+
+	return &importBlocks, nil
+}
+
+func (r *PingoneMFAApplicationPushCredentialResource) ResourceType() string {
+	return "pingone_mfa_application_push_credential"
+}

--- a/internal/connector/pingone/mfa/resources/pingone_mfa_application_push_credential_test.go
+++ b/internal/connector/pingone/mfa/resources/pingone_mfa_application_push_credential_test.go
@@ -1,0 +1,37 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/mfa/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestMFAApplicationPushCredentialExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.MFAApplicationPushCredential(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_mfa_application_push_credential",
+			ResourceName: "Test MFA_APNS",
+			ResourceID:   fmt.Sprintf("%s/11cfc8c7-ec0c-43ff-b49a-64f5e243f932/7847f8a4-f81e-4994-a095-b4d579deaf52", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_mfa_application_push_credential",
+			ResourceName: "Test MFA_FCM",
+			ResourceID:   fmt.Sprintf("%s/11cfc8c7-ec0c-43ff-b49a-64f5e243f932/e22e0f8f-ed88-4bdd-a914-5a93202083d0", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_mfa_application_push_credential",
+			ResourceName: "Test MFA_HMS",
+			ResourceID:   fmt.Sprintf("%s/11cfc8c7-ec0c-43ff-b49a-64f5e243f932/e609b3a8-b112-4062-8031-e9ff0d87c9e9", testutils.GetEnvironmentID()),
+		},
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
+}

--- a/internal/connector/pingone/mfa/resources/pingone_mfa_fido2_policy.go
+++ b/internal/connector/pingone/mfa/resources/pingone_mfa_fido2_policy.go
@@ -1,0 +1,70 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/common"
+	"github.com/pingidentity/pingctl/internal/logger"
+)
+
+// Verify that the resource satisfies the exportable resource interface
+var (
+	_ connector.ExportableResource = &PingoneMFAFido2PolicyResource{}
+)
+
+type PingoneMFAFido2PolicyResource struct {
+	clientInfo *connector.SDKClientInfo
+}
+
+// Utility method for creating a PingoneMFAFido2PolicyResource
+func MFAFido2Policy(clientInfo *connector.SDKClientInfo) *PingoneMFAFido2PolicyResource {
+	return &PingoneMFAFido2PolicyResource{
+		clientInfo: clientInfo,
+	}
+}
+
+func (r *PingoneMFAFido2PolicyResource) ExportAll() (*[]connector.ImportBlock, error) {
+	l := logger.Get()
+
+	l.Debug().Msgf("Fetching all %s resources...", r.ResourceType())
+
+	apiExecuteFunc := r.clientInfo.ApiClient.MFAAPIClient.FIDO2PolicyApi.ReadFIDO2Policies(r.clientInfo.Context, r.clientInfo.ExportEnvironmentID).Execute
+	apiFunctionName := "ReadFIDO2Policies"
+
+	embedded, err := common.GetMFAEmbedded(apiExecuteFunc, apiFunctionName, r.ResourceType())
+	if err != nil {
+		return nil, err
+	}
+
+	importBlocks := []connector.ImportBlock{}
+
+	l.Debug().Msgf("Generating Import Blocks for all %s resources...", r.ResourceType())
+
+	for _, fido2Policy := range embedded.GetFido2Policies() {
+		fido2PolicyName, fido2PolicyNameOk := fido2Policy.GetNameOk()
+		fido2PolicyId, fido2PolicyIdOk := fido2Policy.GetIdOk()
+
+		if fido2PolicyNameOk && fido2PolicyIdOk {
+			commentData := map[string]string{
+				"Resource Type":         r.ResourceType(),
+				"FIDO2 Policy Name":     *fido2PolicyName,
+				"Export Environment ID": r.clientInfo.ExportEnvironmentID,
+				"FIDO2 Policy ID":       *fido2PolicyId,
+			}
+
+			importBlocks = append(importBlocks, connector.ImportBlock{
+				ResourceType:       r.ResourceType(),
+				ResourceName:       *fido2PolicyName,
+				ResourceID:         fmt.Sprintf("%s/%s", r.clientInfo.ExportEnvironmentID, *fido2PolicyId),
+				CommentInformation: common.GenerateCommentInformation(commentData),
+			})
+		}
+	}
+
+	return &importBlocks, nil
+}
+
+func (r *PingoneMFAFido2PolicyResource) ResourceType() string {
+	return "pingone_mfa_fido2_policy"
+}

--- a/internal/connector/pingone/mfa/resources/pingone_mfa_fido2_policy_test.go
+++ b/internal/connector/pingone/mfa/resources/pingone_mfa_fido2_policy_test.go
@@ -1,0 +1,32 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/mfa/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestMFAFido2PolicyExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.MFAFido2Policy(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_mfa_fido2_policy",
+			ResourceName: "Passkeys",
+			ResourceID:   fmt.Sprintf("%s/0f9c510a-df48-4d56-9e44-17ac0bc78961", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_mfa_fido2_policy",
+			ResourceName: "Security Keys",
+			ResourceID:   fmt.Sprintf("%s/f8dc3094-cf9f-486f-9ca9-164e0856b0d8", testutils.GetEnvironmentID()),
+		},
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
+}

--- a/internal/connector/pingone/mfa/resources/pingone_mfa_policy.go
+++ b/internal/connector/pingone/mfa/resources/pingone_mfa_policy.go
@@ -1,0 +1,70 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/common"
+	"github.com/pingidentity/pingctl/internal/logger"
+)
+
+// Verify that the resource satisfies the exportable resource interface
+var (
+	_ connector.ExportableResource = &PingoneMFAPolicyResource{}
+)
+
+type PingoneMFAPolicyResource struct {
+	clientInfo *connector.SDKClientInfo
+}
+
+// Utility method for creating a PingoneMFAPolicyResource
+func MFAPolicy(clientInfo *connector.SDKClientInfo) *PingoneMFAPolicyResource {
+	return &PingoneMFAPolicyResource{
+		clientInfo: clientInfo,
+	}
+}
+
+func (r *PingoneMFAPolicyResource) ExportAll() (*[]connector.ImportBlock, error) {
+	l := logger.Get()
+
+	l.Debug().Msgf("Fetching all %s resources...", r.ResourceType())
+
+	apiExecuteFunc := r.clientInfo.ApiClient.MFAAPIClient.DeviceAuthenticationPolicyApi.ReadDeviceAuthenticationPolicies(r.clientInfo.Context, r.clientInfo.ExportEnvironmentID).Execute
+	apiFunctionName := "ReadDeviceAuthenticationPolicies"
+
+	embedded, err := common.GetMFAEmbedded(apiExecuteFunc, apiFunctionName, r.ResourceType())
+	if err != nil {
+		return nil, err
+	}
+
+	importBlocks := []connector.ImportBlock{}
+
+	l.Debug().Msgf("Generating Import Blocks for all %s resources...", r.ResourceType())
+
+	for _, deviceAuthenticationPolicy := range embedded.GetDeviceAuthenticationPolicies() {
+		deviceAuthenticationPolicyName, deviceAuthenticationPolicyNameOk := deviceAuthenticationPolicy.GetNameOk()
+		deviceAuthenticationPolicyId, deviceAuthenticationPolicyIdOk := deviceAuthenticationPolicy.GetIdOk()
+
+		if deviceAuthenticationPolicyNameOk && deviceAuthenticationPolicyIdOk {
+			commentData := map[string]string{
+				"Resource Type":         r.ResourceType(),
+				"MFA Policy Name":       *deviceAuthenticationPolicyName,
+				"Export Environment ID": r.clientInfo.ExportEnvironmentID,
+				"MFA Policy ID":         *deviceAuthenticationPolicyId,
+			}
+
+			importBlocks = append(importBlocks, connector.ImportBlock{
+				ResourceType:       r.ResourceType(),
+				ResourceName:       *deviceAuthenticationPolicyName,
+				ResourceID:         fmt.Sprintf("%s/%s", r.clientInfo.ExportEnvironmentID, *deviceAuthenticationPolicyId),
+				CommentInformation: common.GenerateCommentInformation(commentData),
+			})
+		}
+	}
+
+	return &importBlocks, nil
+}
+
+func (r *PingoneMFAPolicyResource) ResourceType() string {
+	return "pingone_mfa_policy"
+}

--- a/internal/connector/pingone/mfa/resources/pingone_mfa_policy_test.go
+++ b/internal/connector/pingone/mfa/resources/pingone_mfa_policy_test.go
@@ -1,0 +1,32 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/mfa/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestMFAPolicyExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.MFAPolicy(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_mfa_policy",
+			ResourceName: "Default MFA Policy",
+			ResourceID:   fmt.Sprintf("%s/6adc6dfa-d883-08ed-37c5-ea8f61029ad9", testutils.GetEnvironmentID()),
+		},
+		{
+			ResourceType: "pingone_mfa_policy",
+			ResourceName: "Test MFA Policy",
+			ResourceID:   fmt.Sprintf("%s/5ae2227f-cb5b-47c3-bb40-440db09a98e6", testutils.GetEnvironmentID()),
+		},
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
+}

--- a/internal/connector/pingone/mfa/resources/pingone_mfa_settings.go
+++ b/internal/connector/pingone/mfa/resources/pingone_mfa_settings.go
@@ -1,0 +1,62 @@
+package resources
+
+import (
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/common"
+	"github.com/pingidentity/pingctl/internal/logger"
+)
+
+// Verify that the resource satisfies the exportable resource interface
+var (
+	_ connector.ExportableResource = &PingoneMFASettingsResource{}
+)
+
+type PingoneMFASettingsResource struct {
+	clientInfo *connector.SDKClientInfo
+}
+
+// Utility method for creating a PingoneMFASettingsResource
+func MFASettings(clientInfo *connector.SDKClientInfo) *PingoneMFASettingsResource {
+	return &PingoneMFASettingsResource{
+		clientInfo: clientInfo,
+	}
+}
+
+func (r *PingoneMFASettingsResource) ExportAll() (*[]connector.ImportBlock, error) {
+	l := logger.Get()
+
+	l.Debug().Msgf("Fetching all %s resources...", r.ResourceType())
+
+	_, response, err := r.clientInfo.ApiClient.MFAAPIClient.MFASettingsApi.ReadMFASettings(r.clientInfo.Context, r.clientInfo.ExportEnvironmentID).Execute()
+	err = common.HandleClientResponse(response, err, "ReadMFASettings", r.ResourceType())
+	if err != nil {
+		return nil, err
+	}
+
+	importBlocks := []connector.ImportBlock{}
+
+	l.Debug().Msgf("Generating Import Blocks for all %s resources...", r.ResourceType())
+
+	if response.StatusCode == 204 {
+		l.Debug().Msgf("No exportable %s resource found", r.ResourceType())
+		return &importBlocks, nil
+	}
+
+	commentData := map[string]string{
+		"Resource Type":         r.ResourceType(),
+		"Export Environment ID": r.clientInfo.ExportEnvironmentID,
+	}
+
+	importBlocks = append(importBlocks, connector.ImportBlock{
+		ResourceType:       r.ResourceType(),
+		ResourceName:       "mfa_settings",
+		ResourceID:         r.clientInfo.ExportEnvironmentID,
+		CommentInformation: common.GenerateCommentInformation(commentData),
+	})
+
+	return &importBlocks, nil
+}
+
+func (r *PingoneMFASettingsResource) ResourceType() string {
+	return "pingone_mfa_settings"
+}

--- a/internal/connector/pingone/mfa/resources/pingone_mfa_settings_test.go
+++ b/internal/connector/pingone/mfa/resources/pingone_mfa_settings_test.go
@@ -1,0 +1,26 @@
+package resources_test
+
+import (
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingone/mfa/resources"
+	"github.com/pingidentity/pingctl/internal/testutils"
+)
+
+func TestMFASettingsExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	sdkClientInfo := testutils.GetPingOneSDKClientInfo(t)
+	resource := resources.MFASettings(sdkClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingone_mfa_settings",
+			ResourceName: "mfa_settings",
+			ResourceID:   testutils.GetEnvironmentID(),
+		},
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
+}

--- a/internal/connector/pingone/sso/resources/pingone_application_attribute_mapping_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_application_attribute_mapping_test.go
@@ -46,6 +46,11 @@ func TestApplicationAttributeMappingExport(t *testing.T) {
 			ResourceName: "Worker App_sub",
 			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57/f6d41400-e571-432e-9151-4ff06e0b51ce", testutils.GetEnvironmentID()),
 		},
+		{
+			ResourceType: "pingone_application_attribute_mapping",
+			ResourceName: "Test MFA_sub",
+			ResourceID:   fmt.Sprintf("%s/11cfc8c7-ec0c-43ff-b49a-64f5e243f932/f6d41400-e571-432e-9151-4ff06e0b51ce", testutils.GetEnvironmentID()),
+		},
 	}
 
 	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)

--- a/internal/connector/pingone/sso/resources/pingone_application_secret_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_application_secret_test.go
@@ -41,6 +41,11 @@ func TestApplicationSecretExport(t *testing.T) {
 			ResourceName: "test app_secret",
 			ResourceID:   fmt.Sprintf("%s/a4cbf57e-fa2c-452f-bbc8-f40b551da0e2", testutils.GetEnvironmentID()),
 		},
+		{
+			ResourceType: "pingone_application_secret",
+			ResourceName: "Test MFA_secret",
+			ResourceID:   fmt.Sprintf("%s/11cfc8c7-ec0c-43ff-b49a-64f5e243f932", testutils.GetEnvironmentID()),
+		},
 	}
 
 	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)

--- a/internal/connector/pingone/sso/resources/pingone_application_sign_on_policy_assignment_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_application_sign_on_policy_assignment_test.go
@@ -21,6 +21,12 @@ func TestApplicationSignOnPolicyAssignmentExport(t *testing.T) {
 			ResourceName: "Example OAuth App_Single_Factor",
 			ResourceID:   fmt.Sprintf("%s/2a7c1b5d-415b-4fb5-a6c0-1e290f776785/056ed696-f2e9-44b1-8d2c-68e690cd1f24", testutils.GetEnvironmentID()),
 		},
+
+		{
+			ResourceType: "pingone_application_sign_on_policy_assignment",
+			ResourceName: "Test MFA_multi_factor",
+			ResourceID:   fmt.Sprintf("%s/11cfc8c7-ec0c-43ff-b49a-64f5e243f932/b0ecdaab-9d7c-4c1f-ab0d-891cfdbc73b2", testutils.GetEnvironmentID()),
+		},
 	}
 
 	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)

--- a/internal/connector/pingone/sso/resources/pingone_application_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_application_test.go
@@ -46,6 +46,11 @@ func TestApplicationExport(t *testing.T) {
 			ResourceName: "Worker App",
 			ResourceID:   fmt.Sprintf("%s/c45c2f8c-dee0-4a12-b169-bae693a13d57", testutils.GetEnvironmentID()),
 		},
+		{
+			ResourceType: "pingone_application",
+			ResourceName: "Test MFA",
+			ResourceID:   fmt.Sprintf("%s/11cfc8c7-ec0c-43ff-b49a-64f5e243f932", testutils.GetEnvironmentID()),
+		},
 	}
 
 	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)

--- a/internal/connector/pingone/sso/resources/pingone_sign_on_policy_action_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_sign_on_policy_action_test.go
@@ -41,6 +41,11 @@ func TestSignOnPolicyActionExport(t *testing.T) {
 			ResourceName: "Single_Factor_LOGIN",
 			ResourceID:   fmt.Sprintf("%s/b1fdc38d-ea0c-47b1-9d83-c48105bd6806/6cc634a8-a89f-4632-8e84-45b976a18473", testutils.GetEnvironmentID()),
 		},
+		{
+			ResourceType: "pingone_sign_on_policy_action",
+			ResourceName: "multi_factor_MULTI_FACTOR_AUTHENTICATION",
+			ResourceID:   fmt.Sprintf("%s/7c857f42-12ef-4ff0-96e8-4dfe6d84c425/f370ed1c-09b6-4f84-8a5e-8afd5aa63687", testutils.GetEnvironmentID()),
+		},
 	}
 
 	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)

--- a/internal/connector/pingone/sso/resources/pingone_sign_on_policy_test.go
+++ b/internal/connector/pingone/sso/resources/pingone_sign_on_policy_test.go
@@ -31,6 +31,11 @@ func TestSignOnPolicyExport(t *testing.T) {
 			ResourceName: "Single_Factor",
 			ResourceID:   fmt.Sprintf("%s/b1fdc38d-ea0c-47b1-9d83-c48105bd6806", testutils.GetEnvironmentID()),
 		},
+		{
+			ResourceType: "pingone_sign_on_policy",
+			ResourceName: "multi_factor",
+			ResourceID:   fmt.Sprintf("%s/7c857f42-12ef-4ff0-96e8-4dfe6d84c425", testutils.GetEnvironmentID()),
+		},
 	}
 
 	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)


### PR DESCRIPTION
- Add pingone_mfa_settings resource
- Add pingone_mfa_policy resource
- Add pingone_mfa_fido2_policy resource
- Add pingone_mfa_application_push_credential resource
- Add MFA connector and add it to export.go and custom_types.go
- Add tests for all newly added resources