### PR TITLE
PDI-1901: Update all Cobra command Usages and Examples

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -6,12 +6,15 @@ import (
 
 func NewAuthCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "auth",
-		Short: "Authenticate the CLI with configured Ping connections",
 		Long:  "Authenticate the CLI with configured Ping connections",
+		Short: "Authenticate the CLI with configured Ping connections",
+		Use:   "auth",
 	}
 
-	cmd.AddCommand(NewLoginCommand(), NewLogoutCommand())
+	cmd.AddCommand(
+		NewLoginCommand(),
+		NewLogoutCommand(),
+	)
 
 	return cmd
 }

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -1,19 +1,26 @@
 package auth
 
 import (
+	"github.com/pingidentity/pingctl/cmd/common"
 	"github.com/spf13/cobra"
 )
 
 func NewLoginCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "login",
-		Short: "Login user to the CLI",
-		Long:  "Login user to the CLI",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			// authConnectors := []connector.Authenticatable{}
-			return nil
-		},
+		Args:                  common.ExactArgs(0),
+		DisableFlagsInUseLine: true, // We write our own flags in @Use attribute
+		Long:                  "Login user to the CLI",
+		RunE:                  AuthLoginRunE,
+		Short:                 "Login user to the CLI",
+		Use:                   "login [flags]",
 	}
 
 	return cmd
+}
+
+func AuthLoginRunE(cmd *cobra.Command, args []string) error {
+	// l := logger.Get()
+	// l.Debug().Msgf("Auth Login Subcommand Called.")
+
+	return nil
 }

--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -1,19 +1,26 @@
 package auth
 
 import (
+	"github.com/pingidentity/pingctl/cmd/common"
 	"github.com/spf13/cobra"
 )
 
 func NewLogoutCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "logout",
-		Short: "Logout user from the CLI",
-		Long:  "Logout user from the CLI",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			// authConnectors := []connector.Authenticatable{}
-			return nil
-		},
+		Args:                  common.ExactArgs(0),
+		DisableFlagsInUseLine: true, // We write our own flags in @Use attribute
+		Long:                  "Logout user from the CLI",
+		RunE:                  AuthLogoutRunE,
+		Short:                 "Logout user from the CLI",
+		Use:                   "logout [flags]",
 	}
 
 	return cmd
+}
+
+func AuthLogoutRunE(cmd *cobra.Command, args []string) error {
+	// l := logger.Get()
+	// l.Debug().Msgf("Auth Logout Subcommand Called.")
+
+	return nil
 }

--- a/cmd/common/cobra_utils.go
+++ b/cmd/common/cobra_utils.go
@@ -1,0 +1,25 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func ExactArgs(numArgs int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) != numArgs {
+			return fmt.Errorf("failed to execute '%s': command accepts %d arg(s), received %d", cmd.CommandPath(), numArgs, len(args))
+		}
+		return nil
+	}
+}
+
+func RangeArgs(min, max int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) < min || len(args) > max {
+			return fmt.Errorf("failed to execute '%s': command accepts %d to %d arg(s), received %d", cmd.CommandPath(), min, max, len(args))
+		}
+		return nil
+	}
+}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -7,9 +7,9 @@ import (
 
 func NewConfigCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "config",
-		Short: "Command to get, set, and unset pingctl configuration settings.",
 		Long:  `Command to get, set, and unset pingctl configuration settings.`,
+		Short: "Command to get, set, and unset pingctl configuration settings.",
+		Use:   "config",
 	}
 
 	cmd.AddCommand(NewConfigGetCommand())

--- a/cmd/config/get.go
+++ b/cmd/config/get.go
@@ -1,19 +1,26 @@
 package config
 
 import (
+	"github.com/pingidentity/pingctl/cmd/common"
 	config_internal "github.com/pingidentity/pingctl/internal/commands/config"
 	"github.com/pingidentity/pingctl/internal/logger"
 	"github.com/spf13/cobra"
 )
 
+var ()
+
 func NewConfigGetCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get",
+		Args:                  common.RangeArgs(0, 1),
+		DisableFlagsInUseLine: true, // We write our own flags in @Use attribute
+		Example: `pingctl config get
+pingctl config get pingone
+pingctl config get pingctl.color
+pingctl config get pingone.export.environmentID`,
+		Use:   "get [flags] [key]",
 		Short: "Get pingctl configuration settings.",
-		Long: `Get pingctl configuration settings.
-
-Example command usage: 'pingctl config get pingctl.color'`,
-		RunE: ConfigGetRunE,
+		Long:  `Get pingctl configuration settings.`,
+		RunE:  ConfigGetRunE,
 	}
 
 	return cmd
@@ -23,7 +30,12 @@ func ConfigGetRunE(cmd *cobra.Command, args []string) error {
 	l := logger.Get()
 	l.Debug().Msgf("Config Get Subcommand Called.")
 
-	if err := config_internal.RunInternalConfigGet(args); err != nil {
+	key := ""
+	if len(args) > 0 {
+		key = args[0]
+	}
+
+	if err := config_internal.RunInternalConfigGet(key); err != nil {
 		return err
 	}
 

--- a/cmd/config/get_test.go
+++ b/cmd/config/get_test.go
@@ -14,6 +14,13 @@ func TestConfigGetCmd_Execute(t *testing.T) {
 	testutils.CheckExpectedError(t, err, nil)
 }
 
+// Test Config Get Command fails when provided too many arguments
+func TestConfigGetCmd_TooManyArgs(t *testing.T) {
+	expectedErrorPattern := `^failed to execute 'pingctl config get': command accepts 0 to 1 arg\(s\), received 2$`
+	err := testutils_cobra.ExecutePingctl(t, "config", "get", profiles.ColorOption.ViperKey, profiles.OutputOption.ViperKey)
+	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
+}
+
 // Test Config Get Command Executes when provided a full key
 func TestConfigGetCmd_FullKey(t *testing.T) {
 	err := testutils_cobra.ExecutePingctl(t, "config", "get", profiles.WorkerClientIDOption.ViperKey)
@@ -31,10 +38,4 @@ func TestConfigGetCmd_InvalidKey(t *testing.T) {
 	expectedErrorPattern := `^unable to get configuration: value 'pingctl\.invalid' is not recognized as a valid configuration key\. Valid keys: [A-Za-z\.\s,]+$`
 	err := testutils_cobra.ExecutePingctl(t, "config", "get", "pingctl.invalid")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test Config Get Command Executes normally when too many arguments are provided
-func TestConfigGetCmd_TooManyArgs(t *testing.T) {
-	err := testutils_cobra.ExecutePingctl(t, "config", "get", profiles.ColorOption.ViperKey, profiles.OutputOption.ViperKey)
-	testutils.CheckExpectedError(t, err, nil)
 }

--- a/cmd/config/profile/add_test.go
+++ b/cmd/config/profile/add_test.go
@@ -13,6 +13,13 @@ func TestConfigProfileAddCmd_Execute(t *testing.T) {
 	testutils.CheckExpectedError(t, err, nil)
 }
 
+// Test Config Profile Add Command fails when provided too many arguments
+func TestConfigProfileAddCmd_TooManyArgs(t *testing.T) {
+	expectedErrorPattern := `^failed to execute 'pingctl config profile add': command accepts 0 arg\(s\), received 1$`
+	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "add", "extra-arg")
+	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
+}
+
 // Test Config Profile Add Command fails when provided an invalid profile name
 func TestConfigProfileAddCmd_InvalidProfileName(t *testing.T) {
 	expectedErrorPattern := `^invalid profile name: '.*'. name must contain only alphanumeric characters, underscores, and dashes$`
@@ -43,7 +50,7 @@ func TestConfigProfileAddCmd_NoProfileDescription(t *testing.T) {
 
 // Test Config Profile Add Command fails when set-active flag is provided an invalid value
 func TestConfigProfileAddCmd_InvalidSetActiveValue(t *testing.T) {
-	expectedErrorPattern := `^invalid argument "invalid" for "--set-active" flag: strconv.ParseBool: parsing "invalid": invalid syntax$`
+	expectedErrorPattern := `^invalid argument "invalid" for "-s, --set-active" flag: strconv.ParseBool: parsing "invalid": invalid syntax$`
 	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "add", "--name", "new-test-profile-name", "--set-active=invalid", "--description", "test-description")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
@@ -53,12 +60,6 @@ func TestConfigProfileAddCmd_InvalidFlag(t *testing.T) {
 	expectedErrorPattern := `^unknown flag: --invalid$`
 	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "add", "--invalid")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test Config Profile Add Command executes successfully when provided too many arguments
-func TestConfigProfileAddCmd_TooManyArgs(t *testing.T) {
-	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "add", "--name", "new-test-profile-name", "--set-active", "--description", "test-description", "extra-arg1", "extra-arg2")
-	testutils.CheckExpectedError(t, err, nil)
 }
 
 // Test Config Profile Add Command executes successfully when provided help flag

--- a/cmd/config/profile/delete.go
+++ b/cmd/config/profile/delete.go
@@ -1,6 +1,7 @@
 package profile
 
 import (
+	"github.com/pingidentity/pingctl/cmd/common"
 	profile_internal "github.com/pingidentity/pingctl/internal/commands/config/profile"
 	"github.com/pingidentity/pingctl/internal/logger"
 	"github.com/spf13/cobra"
@@ -8,10 +9,13 @@ import (
 
 func NewConfigProfileDeleteCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete",
-		Short: "Command to delete a configuration profile.",
-		Long:  `Command to delete a configuration profile.`,
-		RunE:  ConfigProfileDeleteRunE,
+		Args:                  common.ExactArgs(1),
+		DisableFlagsInUseLine: true, // We write our own flags in @Use attribute
+		Example:               `pingctl config profile delete my-profile`,
+		Long:                  `Command to delete a configuration profile.`,
+		RunE:                  ConfigProfileDeleteRunE,
+		Short:                 "Command to delete a configuration profile.",
+		Use:                   "delete [flags] profile",
 	}
 
 	return cmd
@@ -21,7 +25,7 @@ func ConfigProfileDeleteRunE(cmd *cobra.Command, args []string) error {
 	l := logger.Get()
 	l.Debug().Msgf("Config Profile Delete Subcommand Called.")
 
-	if err := profile_internal.RunInternalConfigProfileDelete(args); err != nil {
+	if err := profile_internal.RunInternalConfigProfileDelete(args[0]); err != nil {
 		return err
 	}
 

--- a/cmd/config/profile/delete_test.go
+++ b/cmd/config/profile/delete_test.go
@@ -13,24 +13,25 @@ func TestConfigProfileDeleteCmd_Execute(t *testing.T) {
 	testutils.CheckExpectedError(t, err, nil)
 }
 
+// Test Config Profile Delete Command fails when provided too few arguments
+func TestConfigProfileDeleteCmd_TooFewArgs(t *testing.T) {
+	expectedErrorPattern := `^failed to execute 'pingctl config profile delete': command accepts 1 arg\(s\), received 0$`
+	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "delete")
+	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
+}
+
+// Test Config Profile Delete Command fails when provided too many arguments
+func TestConfigProfileDeleteCmd_TooManyArgs(t *testing.T) {
+	expectedErrorPattern := `^failed to execute 'pingctl config profile delete': command accepts 1 arg\(s\), received 2$`
+	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "delete", "production", "extra-arg")
+	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
+}
+
 // Test Config Profile Delete Command fails when provided an non-existent profile name
 func TestConfigProfileDeleteCmd_NonExistentProfileName(t *testing.T) {
 	expectedErrorPattern := `^failed to delete profile: invalid profile name: '.*' profile does not exist$`
 	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "delete", "invalid-profile")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test Config Profile Delete Command fails when no argument is provided
-func TestConfigProfileDeleteCmd_NoProfileName(t *testing.T) {
-	expectedErrorPattern := `^failed to delete profile: profile name is required$`
-	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "delete")
-	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test Config Profile Delete Command executes successfully when too many arguments are provided
-func TestConfigProfileDeleteCmd_TooManyArgs(t *testing.T) {
-	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "delete", "production", "extra-arg1", "extra-arg2")
-	testutils.CheckExpectedError(t, err, nil)
 }
 
 // Test Config Profile Delete Command fails when provided the active profile name

--- a/cmd/config/profile/describe.go
+++ b/cmd/config/profile/describe.go
@@ -1,6 +1,7 @@
 package profile
 
 import (
+	"github.com/pingidentity/pingctl/cmd/common"
 	profile_internal "github.com/pingidentity/pingctl/internal/commands/config/profile"
 	"github.com/pingidentity/pingctl/internal/logger"
 	"github.com/spf13/cobra"
@@ -8,10 +9,12 @@ import (
 
 func NewConfigProfileDescribeCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe",
-		Short: "Command to describe a configuration profile.",
-		Long:  `Command to describe a configuration profile.`,
-		RunE:  ConfigProfileDescribeRunE,
+		Args:    common.ExactArgs(1),
+		Example: `pingctl config profile describe my-profile`,
+		Long:    `Command to describe a configuration profile.`,
+		RunE:    ConfigProfileDescribeRunE,
+		Short:   "Command to describe a configuration profile.",
+		Use:     "describe [flags] profile",
 	}
 
 	return cmd
@@ -21,7 +24,7 @@ func ConfigProfileDescribeRunE(cmd *cobra.Command, args []string) error {
 	l := logger.Get()
 	l.Debug().Msgf("Config Profile Describe Subcommand Called.")
 
-	if err := profile_internal.RunInternalConfigProfileDescribe(args); err != nil {
+	if err := profile_internal.RunInternalConfigProfileDescribe(args[0]); err != nil {
 		return err
 	}
 

--- a/cmd/config/profile/describe_test.go
+++ b/cmd/config/profile/describe_test.go
@@ -13,24 +13,25 @@ func TestConfigProfileDescribeCmd_Execute(t *testing.T) {
 	testutils.CheckExpectedError(t, err, nil)
 }
 
+// Test Config Profile Describe Command fails when provided too few arguments
+func TestConfigProfileDescribeCmd_TooFewArgs(t *testing.T) {
+	expectedErrorPattern := `^failed to execute 'pingctl config profile describe': command accepts 1 arg\(s\), received 0$`
+	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "describe")
+	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
+}
+
+// Test Config Profile Describe Command fails when provided too many arguments
+func TestConfigProfileDescribeCmd_TooManyArgs(t *testing.T) {
+	expectedErrorPattern := `^failed to execute 'pingctl config profile describe': command accepts 1 arg\(s\), received 2$`
+	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "describe", "production", "extra-arg")
+	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
+}
+
 // Test Config Profile Describe Command fails when provided an non-existent profile name
 func TestConfigProfileDescribeCmd_NonExistentProfileName(t *testing.T) {
 	expectedErrorPattern := `^failed to describe profile: invalid profile name: '.*' profile does not exist$`
 	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "describe", "invalid-profile")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test Config Profile Describe Command fails when no argument is provided
-func TestConfigProfileDescribeCmd_NoProfileName(t *testing.T) {
-	expectedErrorPattern := `^failed to describe profile: profile name is required$`
-	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "describe")
-	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test Config Profile Describe Command executes successfully when too many arguments are provided
-func TestConfigProfileDescribeCmd_TooManyArgs(t *testing.T) {
-	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "describe", "production", "extra-arg1", "extra-arg2")
-	testutils.CheckExpectedError(t, err, nil)
 }
 
 // Test Config Profile Describe Command fails when provided an invalid flag

--- a/cmd/config/profile/list.go
+++ b/cmd/config/profile/list.go
@@ -1,6 +1,7 @@
 package profile
 
 import (
+	"github.com/pingidentity/pingctl/cmd/common"
 	profile_internal "github.com/pingidentity/pingctl/internal/commands/config/profile"
 	"github.com/pingidentity/pingctl/internal/logger"
 	"github.com/spf13/cobra"
@@ -8,10 +9,12 @@ import (
 
 func NewConfigProfileListCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "Command to list all configuration profiles.",
-		Long:  `Command to list all configuration profiles.`,
-		RunE:  ConfigProfileListRunE,
+		Args:                  common.ExactArgs(0),
+		DisableFlagsInUseLine: true, // We write our own flags in @Use attribute
+		Long:                  `Command to list all configuration profiles.`,
+		RunE:                  ConfigProfileListRunE,
+		Short:                 "Command to list all configuration profiles.",
+		Use:                   "list [flags]",
 	}
 
 	return cmd
@@ -21,7 +24,7 @@ func ConfigProfileListRunE(cmd *cobra.Command, args []string) error {
 	l := logger.Get()
 	l.Debug().Msgf("Config Profile List Subcommand Called.")
 
-	profile_internal.RunInternalConfigProfileList(args)
+	profile_internal.RunInternalConfigProfileList()
 
 	return nil
 }

--- a/cmd/config/profile/list_test.go
+++ b/cmd/config/profile/list_test.go
@@ -13,10 +13,11 @@ func TestConfigProfileListCmd_Execute(t *testing.T) {
 	testutils.CheckExpectedError(t, err, nil)
 }
 
-// Test Config Profile List Command executes successfully when provided too many arguments
+// Test Config Profile List Command fails when provided too many arguments
 func TestConfigProfileListCmd_TooManyArgs(t *testing.T) {
-	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "list", "extra-arg1", "extra-arg2")
-	testutils.CheckExpectedError(t, err, nil)
+	expectedErrorPattern := `^failed to execute '.*': command accepts \d arg\(s\), received 1$`
+	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "list", "extra-arg")
+	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
 
 // Test Config Profile List Command executes successfully when provided the help flag

--- a/cmd/config/profile/profile.go
+++ b/cmd/config/profile/profile.go
@@ -6,9 +6,9 @@ import (
 
 func NewConfigProfileCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "profile",
-		Short: "Command to add, list, describe, delete, and set active configuration profiles.",
 		Long:  `Command to add, list, describe, delete, and set active configuration profiles.`,
+		Short: "Command to add, list, describe, delete, and set active configuration profiles.",
+		Use:   "profile",
 	}
 
 	cmd.AddCommand(

--- a/cmd/config/profile/set_active.go
+++ b/cmd/config/profile/set_active.go
@@ -1,6 +1,7 @@
 package profile
 
 import (
+	"github.com/pingidentity/pingctl/cmd/common"
 	profile_internal "github.com/pingidentity/pingctl/internal/commands/config/profile"
 	"github.com/pingidentity/pingctl/internal/logger"
 	"github.com/spf13/cobra"
@@ -8,10 +9,12 @@ import (
 
 func NewConfigProfileSetActiveCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "set-active",
-		Short: "Command to set the active configuration profile.",
-		Long:  `Command to set the active configuration profile.`,
-		RunE:  ConfigProfileSetActiveRunE,
+		Args:    common.ExactArgs(1),
+		Example: `pingctl config profile set-active my-profile`,
+		Long:    `Command to set the active configuration profile.`,
+		RunE:    ConfigProfileSetActiveRunE,
+		Short:   "Command to set the active configuration profile.",
+		Use:     "set-active [flags] profile",
 	}
 
 	return cmd
@@ -21,7 +24,7 @@ func ConfigProfileSetActiveRunE(cmd *cobra.Command, args []string) error {
 	l := logger.Get()
 	l.Debug().Msgf("Config Profile set-active Subcommand Called.")
 
-	if err := profile_internal.RunInternalConfigProfileSetActive(args); err != nil {
+	if err := profile_internal.RunInternalConfigProfileSetActive(args[0]); err != nil {
 		return err
 	}
 

--- a/cmd/config/profile/set_active_test.go
+++ b/cmd/config/profile/set_active_test.go
@@ -13,24 +13,25 @@ func TestConfigProfileSetActiveCmd_Execute(t *testing.T) {
 	testutils.CheckExpectedError(t, err, nil)
 }
 
+// Test Config Profile Set-Active Command fails when provided too few arguments
+func TestConfigProfileSetActiveCmd_TooFewArgs(t *testing.T) {
+	expectedErrorPattern := `^failed to execute 'pingctl config profile set-active': command accepts 1 arg\(s\), received 0$`
+	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "set-active")
+	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
+}
+
+// Test Config Profile Set-Active Command fails when provided too many arguments
+func TestConfigProfileSetActiveCmd_TooManyArgs(t *testing.T) {
+	expectedErrorPattern := `^failed to execute 'pingctl config profile set-active': command accepts 1 arg\(s\), received 2$`
+	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "set-active", "production", "extra-arg")
+	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
+}
+
 // Test Config Profile Set-Active Command fails when provided an non-existent profile name
 func TestConfigProfileSetActiveCmd_NonExistentProfileName(t *testing.T) {
 	expectedErrorPattern := `^failed to set active profile: invalid profile name: '.*' profile does not exist$`
 	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "set-active", "invalid-profile")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test Config Profile Set-Active Command fails when no argument is provided
-func TestConfigProfileSetActiveCmd_NoProfileName(t *testing.T) {
-	expectedErrorPattern := `^failed to set active profile: profile name is required$`
-	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "set-active")
-	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test Config Profile Set-Active Command executes successfully when too many arguments are provided
-func TestConfigProfileSetActiveCmd_TooManyArgs(t *testing.T) {
-	err := testutils_cobra.ExecutePingctl(t, "config", "profile", "production", "production", "extra-arg1", "extra-arg2")
-	testutils.CheckExpectedError(t, err, nil)
 }
 
 // Test Config Profile Set-Active Command executes successfully when provided the already active profile name

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/pingidentity/pingctl/cmd/common"
 	config_internal "github.com/pingidentity/pingctl/internal/commands/config"
 	"github.com/pingidentity/pingctl/internal/logger"
 	"github.com/spf13/cobra"
@@ -8,12 +9,14 @@ import (
 
 func NewConfigSetCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "set",
+		Args:                  common.ExactArgs(1),
+		DisableFlagsInUseLine: true, // We write our own flags in @Use attribute
+		Example: `pingctl config set pingctl.color=true
+pingctl config set pingone.region=AsiaPacific`,
+		Long:  `Set pingctl configuration settings.`,
+		RunE:  ConfigSetRunE,
 		Short: "Set pingctl configuration settings.",
-		Long: `Set pingctl configuration settings.
-
-Example command usage: 'pingctl config set pingctl.color=false'`,
-		RunE: ConfigSetRunE,
+		Use:   "set [flags] key=value",
 	}
 
 	return cmd
@@ -22,7 +25,7 @@ func ConfigSetRunE(cmd *cobra.Command, args []string) error {
 	l := logger.Get()
 	l.Debug().Msgf("Config Get Subcommand Called.")
 
-	if err := config_internal.RunInternalConfigSet(args); err != nil {
+	if err := config_internal.RunInternalConfigSet(args[0]); err != nil {
 		return err
 	}
 

--- a/cmd/config/set_test.go
+++ b/cmd/config/set_test.go
@@ -15,10 +15,17 @@ func TestConfigSetCmd_Execute(t *testing.T) {
 	testutils.CheckExpectedError(t, err, nil)
 }
 
-// Test Config Set Command Fails when no arguments are provided
-func TestConfigSetCmd_NoArgs(t *testing.T) {
-	expectedErrorPattern := `^failed to set configuration: no 'key=value' assignment given in set command$`
+// Test Config Set Command Fails when provided too few arguments
+func TestConfigSetCmd_TooFewArgs(t *testing.T) {
+	expectedErrorPattern := `^failed to execute 'pingctl config set': command accepts 1 arg\(s\), received 0$`
 	err := testutils_cobra.ExecutePingctl(t, "config", "set")
+	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
+}
+
+// Test Config Set Command Fails when provided too many arguments
+func TestConfigSetCmd_TooManyArgs(t *testing.T) {
+	expectedErrorPattern := `^failed to execute 'pingctl config set': command accepts 1 arg\(s\), received 2$`
+	err := testutils_cobra.ExecutePingctl(t, "config", "set", fmt.Sprintf("%s=false", profiles.ColorOption.ViperKey), fmt.Sprintf("%s=true", profiles.ColorOption.ViperKey))
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
 
@@ -41,12 +48,6 @@ func TestConfigSetCmd_NoValueProvided(t *testing.T) {
 	expectedErrorPattern := `^failed to set configuration: value for key 'pingctl\.color' is empty\. Use 'pingctl config unset pingctl\.color' to unset the key$`
 	err := testutils_cobra.ExecutePingctl(t, "config", "set", fmt.Sprintf("%s=", profiles.ColorOption.ViperKey))
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test Config Set Command Executes normally when too many arguments are provided
-func TestConfigSetCmd_TooManyArgs(t *testing.T) {
-	err := testutils_cobra.ExecutePingctl(t, "config", "set", fmt.Sprintf("%s=false", profiles.ColorOption.ViperKey), fmt.Sprintf("%s=json", profiles.OutputOption.ViperKey))
-	testutils.CheckExpectedError(t, err, nil)
 }
 
 // Test Config Set Command for key 'pingone.worker.clientId' updates viper configuration

--- a/cmd/config/unset.go
+++ b/cmd/config/unset.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/pingidentity/pingctl/cmd/common"
 	config_internal "github.com/pingidentity/pingctl/internal/commands/config"
 	"github.com/pingidentity/pingctl/internal/logger"
 	"github.com/spf13/cobra"
@@ -8,12 +9,14 @@ import (
 
 func NewConfigUnsetCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "unset",
+		Args:                  common.ExactArgs(1),
+		DisableFlagsInUseLine: true, // We write our own flags in @Use attribute
+		Example: `pingctl config unset pingctl.color
+pingctl config unset pingone.region`,
+		Long:  `Unset pingctl configuration settings.`,
+		RunE:  ConfigUnsetRunE,
 		Short: "Unset pingctl configuration settings.",
-		Long: `Unset pingctl configuration settings.
-
-Example command usage: 'pingctl config unset pingctl.color'`,
-		RunE: ConfigUnsetRunE,
+		Use:   "unset [flags] key",
 	}
 
 	return cmd
@@ -22,7 +25,7 @@ func ConfigUnsetRunE(cmd *cobra.Command, args []string) error {
 	l := logger.Get()
 	l.Debug().Msgf("Config Get Subcommand Called.")
 
-	if err := config_internal.RunInternalConfigUnset(args); err != nil {
+	if err := config_internal.RunInternalConfigUnset(args[0]); err != nil {
 		return err
 	}
 

--- a/cmd/config/unset_test.go
+++ b/cmd/config/unset_test.go
@@ -15,10 +15,17 @@ func TestConfigUnsetCmd_Execute(t *testing.T) {
 	testutils.CheckExpectedError(t, err, nil)
 }
 
-// Test Config Unset Command Fails when no arguments are provided
-func TestConfigUnsetCmd_NoArgs(t *testing.T) {
-	expectedErrorPattern := `^unable to unset configuration: no key given in unset command$`
+// Test Config Set Command Fails when provided too few arguments
+func TestConfigUnsetCmd_TooFewArgs(t *testing.T) {
+	expectedErrorPattern := `^failed to execute 'pingctl config unset': command accepts 1 arg\(s\), received 0$`
 	err := testutils_cobra.ExecutePingctl(t, "config", "unset")
+	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
+}
+
+// Test Config Set Command Fails when provided too many arguments
+func TestConfigUnsetCmd_TooManyArgs(t *testing.T) {
+	expectedErrorPattern := `^failed to execute 'pingctl config unset': command accepts 1 arg\(s\), received 2$`
+	err := testutils_cobra.ExecutePingctl(t, "config", "unset", profiles.ColorOption.ViperKey, profiles.OutputOption.ViperKey)
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
 
@@ -27,12 +34,6 @@ func TestConfigUnsetCmd_InvalidKey(t *testing.T) {
 	expectedErrorPattern := `^unable to unset configuration: key 'pingctl\.invalid' is not recognized as a valid configuration key\. Valid keys: [A-Za-z\.\s,]+$`
 	err := testutils_cobra.ExecutePingctl(t, "config", "unset", "pingctl.invalid")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test Config Unset Command Executes normally when too many arguments are provided
-func TestConfigUnsetCmd_TooManyArgs(t *testing.T) {
-	err := testutils_cobra.ExecutePingctl(t, "config", "unset", profiles.ColorOption.ViperKey, profiles.OutputOption.ViperKey)
-	testutils.CheckExpectedError(t, err, nil)
 }
 
 // Test Config Unset Command for key 'pingone.worker.clientId' updates viper configuration

--- a/cmd/feedback/feedback.go
+++ b/cmd/feedback/feedback.go
@@ -1,6 +1,7 @@
 package feedback
 
 import (
+	"github.com/pingidentity/pingctl/cmd/common"
 	feedback_internal "github.com/pingidentity/pingctl/internal/commands/feedback"
 	"github.com/pingidentity/pingctl/internal/logger"
 	"github.com/spf13/cobra"
@@ -8,12 +9,15 @@ import (
 
 func NewFeedbackCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "feedback",
-		Short: "Information on tool feedback",
+		Args:                  common.ExactArgs(0),
+		DisableFlagsInUseLine: true, // We write our own flags in @Use attribute
+		Example:               `pingctl feedback`,
 		Long: `A command to provide the user information
 on how to give feedback or get help with the tool
 through the use of the GitHub repository's issue tracker.`,
-		RunE: feedbackRunE,
+		RunE:  feedbackRunE,
+		Short: "Information on tool feedback",
+		Use:   "feedback [flags]",
 	}
 
 	return cmd

--- a/cmd/feedback/feedback_test.go
+++ b/cmd/feedback/feedback_test.go
@@ -13,10 +13,11 @@ func TestFeedbackCmd_Execute(t *testing.T) {
 	testutils.CheckExpectedError(t, err, nil)
 }
 
-// Test Feedback Command Executes without issue when provided additional arguments
+// Test Feedback Command fails when provided too many arguments
 func TestFeedbackCmd_TooManyArgs(t *testing.T) {
-	err := testutils_cobra.ExecutePingctl(t, "feedback", "arg1", "arg2", "arg3")
-	testutils.CheckExpectedError(t, err, nil)
+	expectedErrorPattern := `^failed to execute 'pingctl feedback': command accepts 0 arg\(s\), received 1$`
+	err := testutils_cobra.ExecutePingctl(t, "feedback", "extra-arg")
+	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
 
 // Test Feedback Command help flag

--- a/cmd/platform/export_test.go
+++ b/cmd/platform/export_test.go
@@ -17,6 +17,13 @@ func TestPlatformExportCmd_Execute(t *testing.T) {
 	testutils.CheckExpectedError(t, err, nil)
 }
 
+// Test Platform Export Command fails when provided too many arguments
+func TestPlatformExportCmd_TooManyArgs(t *testing.T) {
+	expectedErrorPattern := `^failed to execute 'pingctl platform export': command accepts 0 arg\(s\), received 1$`
+	err := testutils_cobra.ExecutePingctl(t, "platform", "export", "extra-arg")
+	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
+}
+
 // Test Platform Export Command fails when provided invalid flag
 func TestPlatformExportCmd_InvalidFlag(t *testing.T) {
 	expectedErrorPattern := `^unknown flag: --invalid$`
@@ -43,7 +50,7 @@ func TestPlatformExportCmd_ServiceFlag(t *testing.T) {
 
 // Test Platform Export Command --service flag with invalid service
 func TestPlatformExportCmd_ServiceFlagInvalidService(t *testing.T) {
-	expectedErrorPattern := `^invalid argument "invalid" for "--service" flag: unrecognized service 'invalid'\. Must be one of: [a-z-\s,]+$`
+	expectedErrorPattern := `^invalid argument "invalid" for "-s, --service" flag: unrecognized service 'invalid'\. Must be one of: [a-z-\s,]+$`
 	err := testutils_cobra.ExecutePingctl(t, "platform", "export", "--service", "invalid")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
@@ -58,7 +65,7 @@ func TestPlatformExportCmd_ExportFormatFlag(t *testing.T) {
 
 // Test Platform Export Command --export-format flag with invalid format
 func TestPlatformExportCmd_ExportFormatFlagInvalidFormat(t *testing.T) {
-	expectedErrorPattern := `^invalid argument "invalid" for "--export-format" flag: unrecognized export format 'invalid'\. Must be one of: [A-Z]+$`
+	expectedErrorPattern := `^invalid argument "invalid" for "-e, --export-format" flag: unrecognized export format 'invalid'\. Must be one of: [A-Z]+$`
 	err := testutils_cobra.ExecutePingctl(t, "platform", "export", "--export-format", "invalid")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }

--- a/cmd/platform/platform.go
+++ b/cmd/platform/platform.go
@@ -6,9 +6,9 @@ import (
 
 func NewPlatformCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "platform",
-		Short: "Provides details and interactions with the connected Ping Platform.",
 		Long:  `Provides details and interactions with the connected Ping Platform.`,
+		Short: "Provides details and interactions with the connected Ping Platform.",
+		Use:   "platform",
 	}
 
 	cmd.AddCommand(NewExportCommand())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,26 +54,26 @@ func init() {
 // rootCmd represents the base command when called without any subcommands
 func NewRootCommand() *cobra.Command {
 	cmd := &cobra.Command{
+		Long:          `A CLI tool for managing Ping Identity products.`,
+		Short:         "A CLI tool for managing Ping Identity products.",
+		SilenceErrors: true, // Upon error in RunE method, let output package in main.go handle error output
 		Use:           "pingctl",
 		Version:       "v2.0.0-alpha.4",
-		Short:         "A CLI tool for managing Ping Identity products.",
-		Long:          `A CLI tool for managing Ping Identity products.`,
-		SilenceErrors: true, // Upon error in RunE method, let output package in main.go handle error output
 	}
 
 	cmd.AddCommand(
-		platform.NewPlatformCommand(),
-		feedback.NewFeedbackCommand(),
-		config.NewConfigCommand(),
 		// auth.NewAuthCommand(),
+		config.NewConfigCommand(),
+		feedback.NewFeedbackCommand(),
+		platform.NewPlatformCommand(),
 	)
 
 	// flags used within this file assigned to variables
-	cmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Configuration file location (default \"$HOME/.pingctl/config.yaml\"")
-	cmd.PersistentFlags().StringVar(&profileName, profiles.ProfileOption.CobraParamName, "", "Profile to use from configuration file (default \"default\")")
+	cmd.PersistentFlags().StringVarP(&cfgFile, "config", "C", "", "Configuration file location (default \"$HOME/.pingctl/config.yaml\")")
+	cmd.PersistentFlags().StringVarP(&profileName, profiles.ProfileOption.CobraParamName, "P", "", "Profile to use from configuration file")
 
 	// custom pflag.Value types use Var() method
-	cmd.PersistentFlags().Var(&outputFormat, profiles.OutputOption.CobraParamName, fmt.Sprintf("Specifies output format\nValid output options: %s", strings.Join(customtypes.OutputFormatValidValues(), ", ")))
+	cmd.PersistentFlags().VarP(&outputFormat, profiles.OutputOption.CobraParamName, "O", fmt.Sprintf("Specifies output format. Valid formats: %s", strings.Join(customtypes.OutputFormatValidValues(), ", ")))
 	profiles.AddPFlagBinding(profiles.Binding{
 		Option: profiles.OutputOption,
 		Flag:   cmd.PersistentFlags().Lookup(profiles.OutputOption.CobraParamName),

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -14,10 +14,10 @@ func TestRootCmd_Execute(t *testing.T) {
 	testutils.CheckExpectedError(t, err, nil)
 }
 
-// Test Root Command Executes fails when provided additional arguments
-func TestRootCmd_TooManyArgs(t *testing.T) {
-	expectedErrorPattern := `^unknown command "arg1" for "pingctl"$`
-	err := testutils_cobra.ExecutePingctl(t, "arg1")
+// Test Root Command Executes fails when provided an invalid command
+func TestRootCmd_InvalidCommand(t *testing.T) {
+	expectedErrorPattern := `^unknown command "invalid" for "pingctl"$`
+	err := testutils_cobra.ExecutePingctl(t, "invalid")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
 
@@ -46,34 +46,34 @@ func TestRootCmd_VersionFlag(t *testing.T) {
 	testutils.CheckExpectedError(t, err, nil)
 }
 
-// Test Root Command Executes when provided the --output flag
-func TestRootCmd_OutputFlag(t *testing.T) {
+// Test Root Command Executes when provided the --output-format flag
+func TestRootCmd_OutputFormatFlag(t *testing.T) {
 	for _, outputFormat := range customtypes.OutputFormatValidValues() {
-		err := testutils_cobra.ExecutePingctl(t, "--output", outputFormat)
+		err := testutils_cobra.ExecutePingctl(t, "--output-format", outputFormat)
 		testutils.CheckExpectedError(t, err, nil)
 	}
 }
 
-// Test Root Command fails when provided an invalid value for the --output flag
+// Test Root Command fails when provided an invalid value for the --output-format flag
 func TestRootCmd_InvalidOutputFlag(t *testing.T) {
-	expectedErrorPattern := `^invalid argument "invalid" for "--output" flag: unrecognized Output Format: 'invalid'\. Must be one of: [a-z\s,]+$`
-	err := testutils_cobra.ExecutePingctl(t, "--output", "invalid")
+	expectedErrorPattern := `^invalid argument "invalid" for "-O, --output-format" flag: unrecognized Output Format: 'invalid'\. Must be one of: [a-z\s,]+$`
+	err := testutils_cobra.ExecutePingctl(t, "--output-format", "invalid")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
 
-// Test Root Command fails when provided no value for the --output flag
+// Test Root Command fails when provided no value for the --output-format flag
 func TestRootCmd_NoValueOutputFlag(t *testing.T) {
-	expectedErrorPattern := `^flag needs an argument: --output$`
-	err := testutils_cobra.ExecutePingctl(t, "--output")
+	expectedErrorPattern := `^flag needs an argument: --output-format$`
+	err := testutils_cobra.ExecutePingctl(t, "--output-format")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
 
-// Test Root Command Executes output does not change with output=text vs output=json
+// Test Root Command Executes output does not change with output-format=text vs output-format=json
 func TestRootCmd_OutputFlagTextVsJSON(t *testing.T) {
-	textOutput, err := testutils_cobra.ExecutePingctlCaptureCobraOutput(t, "--output=text")
+	textOutput, err := testutils_cobra.ExecutePingctlCaptureCobraOutput(t, "--output-format", "text")
 	testutils.CheckExpectedError(t, err, nil)
 
-	jsonOutput, err := testutils_cobra.ExecutePingctlCaptureCobraOutput(t, "--output=json")
+	jsonOutput, err := testutils_cobra.ExecutePingctlCaptureCobraOutput(t, "--output-format", "json")
 	testutils.CheckExpectedError(t, err, nil)
 
 	if textOutput != jsonOutput {

--- a/internal/commands/config/get_internal.go
+++ b/internal/commands/config/get_internal.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func RunInternalConfigGet(args []string) error {
+func RunInternalConfigGet(viperKey string) error {
 	// Write the profile configuration to file,
 	// even though no configuration change is happening here
 	// This handles the edge case where the config.yaml file was generated for
@@ -19,14 +19,10 @@ func RunInternalConfigGet(args []string) error {
 		return err
 	}
 
-	viperKey, err := parseGetArgs(args)
-	if err != nil {
-		return err
-	}
-
-	// If the viper key is empty,
-	// the parseGetArgs() function already printed the entire configuration
 	if viperKey == "" {
+		if err := PrintConfig(); err != nil {
+			return err
+		}
 		return nil
 	}
 
@@ -54,26 +50,6 @@ func RunInternalConfigGet(args []string) error {
 	}
 
 	return nil
-}
-
-func parseGetArgs(args []string) (string, error) {
-	// If no configuration key is supplied via args, return all configuration settings as YAML
-	if len(args) == 0 {
-		if err := PrintConfig(); err != nil {
-			return "", err
-		}
-		return "", nil
-	}
-
-	if len(args) > 1 {
-		output.Print(output.Opts{
-			Message: fmt.Sprintf("'pingctl config get' only gets one key per command. Ignoring extra arguments: %s", strings.Join(args[1:], " ")),
-			Result:  output.ENUM_RESULT_NOACTION_WARN,
-		})
-	}
-
-	// Assume viper configuration key is args[0] and ignore any other input
-	return args[0], nil
 }
 
 func PrintConfig() error {

--- a/internal/commands/config/get_internal_test.go
+++ b/internal/commands/config/get_internal_test.go
@@ -13,7 +13,7 @@ import (
 func Test_RunInternalConfigGet_NoArgs(t *testing.T) {
 	testutils_viper.InitVipers(t)
 
-	err := RunInternalConfigGet([]string{})
+	err := RunInternalConfigGet("")
 	testutils.CheckExpectedError(t, err, nil)
 }
 
@@ -21,7 +21,7 @@ func Test_RunInternalConfigGet_NoArgs(t *testing.T) {
 func Test_RunInternalConfigGet_WithArgs(t *testing.T) {
 	testutils_viper.InitVipers(t)
 
-	err := RunInternalConfigGet([]string{profiles.ColorOption.ViperKey})
+	err := RunInternalConfigGet(profiles.ColorOption.ViperKey)
 	testutils.CheckExpectedError(t, err, nil)
 }
 
@@ -29,7 +29,7 @@ func Test_RunInternalConfigGet_WithArgs(t *testing.T) {
 func Test_RunInternalConfigGet_WithArgs_NotSet(t *testing.T) {
 	testutils_viper.InitVipers(t)
 
-	err := RunInternalConfigGet([]string{profiles.WorkerClientIDOption.ViperKey})
+	err := RunInternalConfigGet(profiles.WorkerClientIDOption.ViperKey)
 	testutils.CheckExpectedError(t, err, nil)
 }
 
@@ -38,36 +38,8 @@ func Test_RunInternalConfigGet_InvalidKey(t *testing.T) {
 	testutils_viper.InitVipers(t)
 
 	expectedErrorPattern := `^unable to get configuration: value 'pingctl\.invalid' is not recognized as a valid configuration key\. Valid keys: [A-Za-z\.\s,]+$`
-	err := RunInternalConfigGet([]string{"pingctl.invalid"})
+	err := RunInternalConfigGet("pingctl.invalid")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test RunInternalConfigGet function with too many args
-func Test_RunInternalConfigGet_TooManyArgs(t *testing.T) {
-	testutils_viper.InitVipers(t)
-
-	err := RunInternalConfigGet([]string{profiles.WorkerClientIDOption.ViperKey, profiles.WorkerClientSecretOption.ViperKey})
-	testutils.CheckExpectedError(t, err, nil)
-}
-
-// Test parseGetArgs function
-func Test_parseGetArgs(t *testing.T) {
-	_, err := parseGetArgs([]string{profiles.WorkerClientIDOption.ViperKey})
-	testutils.CheckExpectedError(t, err, nil)
-}
-
-// Test parseGetArgs function with no args
-func Test_parseGetArgs_NoArgs(t *testing.T) {
-	testutils_viper.InitVipers(t)
-
-	_, err := parseGetArgs([]string{})
-	testutils.CheckExpectedError(t, err, nil)
-}
-
-// Test parseGetArgs function with too many args
-func Test_parseGetArgs_TooManyArgs(t *testing.T) {
-	_, err := parseGetArgs([]string{profiles.WorkerClientIDOption.ViperKey, profiles.WorkerClientSecretOption.ViperKey})
-	testutils.CheckExpectedError(t, err, nil)
 }
 
 // Test PrintConfig() function
@@ -88,7 +60,7 @@ func Example_printConfig() {
 	// Output:
 	// pingctl:
 	//     color: true
-	//     output: text
+	//     outputformat: text
 	// pingone:
 	//     export:
 	//         environmentid: test-export-environment-id

--- a/internal/commands/config/profile/delete_internal.go
+++ b/internal/commands/config/profile/delete_internal.go
@@ -2,18 +2,12 @@ package profile_internal
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pingidentity/pingctl/internal/output"
 	"github.com/pingidentity/pingctl/internal/profiles"
 )
 
-func RunInternalConfigProfileDelete(args []string) error {
-	pName, err := parseDeleteArgs(args)
-	if err != nil {
-		return fmt.Errorf("failed to delete profile: %v", err)
-	}
-
+func RunInternalConfigProfileDelete(pName string) (err error) {
 	err = profiles.DeleteConfigProfile(pName)
 	if err != nil {
 		return fmt.Errorf("failed to delete profile: %v", err)
@@ -25,19 +19,4 @@ func RunInternalConfigProfileDelete(args []string) error {
 	})
 
 	return nil
-}
-
-func parseDeleteArgs(args []string) (string, error) {
-	if len(args) == 0 {
-		return "", fmt.Errorf("profile name is required")
-	}
-
-	if len(args) > 1 {
-		output.Print(output.Opts{
-			Message: fmt.Sprintf("'pingctl config profile delete' takes only one argument. Ignoring extra arguments: %s", strings.Join(args[1:], " ")),
-			Result:  output.ENUM_RESULT_NOACTION_WARN,
-		})
-	}
-
-	return args[0], nil
 }

--- a/internal/commands/config/profile/delete_internal_test.go
+++ b/internal/commands/config/profile/delete_internal_test.go
@@ -7,29 +7,11 @@ import (
 	"github.com/pingidentity/pingctl/internal/testing/testutils_viper"
 )
 
-// Test RunInternalConfigProfileDelete function with no args
-func Test_RunInternalConfigProfileDelete_NoArgs(t *testing.T) {
+// Test RunInternalConfigProfileDelete function with valid arg
+func Test_RunInternalConfigProfileDelete_ValidArg(t *testing.T) {
 	testutils_viper.InitVipers(t)
 
-	expectedErrorPattern := "^failed to delete profile: profile name is required$"
-	err := RunInternalConfigProfileDelete([]string{})
-	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-
-}
-
-// Test RunInternalConfigProfileDelete function with multiple args
-func Test_RunInternalConfigProfileDelete_MultipleArgs(t *testing.T) {
-	testutils_viper.InitVipers(t)
-
-	err := RunInternalConfigProfileDelete([]string{"production", "extra-arg"})
-	testutils.CheckExpectedError(t, err, nil)
-}
-
-// Test RunInternalConfigProfileDelete function with valid args
-func Test_RunInternalConfigProfileDelete_ValidArgs(t *testing.T) {
-	testutils_viper.InitVipers(t)
-
-	err := RunInternalConfigProfileDelete([]string{"production"})
+	err := RunInternalConfigProfileDelete("production")
 	testutils.CheckExpectedError(t, err, nil)
 }
 
@@ -38,7 +20,7 @@ func Test_RunInternalConfigProfileDelete_InvalidProfileName(t *testing.T) {
 	testutils_viper.InitVipers(t)
 
 	expectedErrorPattern := "^failed to delete profile: invalid profile name: '.*'. name must contain only alphanumeric characters, underscores, and dashes$"
-	err := RunInternalConfigProfileDelete([]string{"invalid&*^*&"})
+	err := RunInternalConfigProfileDelete("invalid&*^*&")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
 
@@ -47,7 +29,7 @@ func Test_RunInternalConfigProfileDelete_NonExistentProfile(t *testing.T) {
 	testutils_viper.InitVipers(t)
 
 	expectedErrorPattern := "^failed to delete profile: invalid profile name: '.*' profile does not exist$"
-	err := RunInternalConfigProfileDelete([]string{"invalid"})
+	err := RunInternalConfigProfileDelete("invalid")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
 
@@ -56,7 +38,7 @@ func Test_RunInternalConfigProfileDelete_ActiveProfile(t *testing.T) {
 	testutils_viper.InitVipers(t)
 
 	expectedErrorPattern := "^failed to delete profile: '.*' is the active profile and cannot be deleted$"
-	err := RunInternalConfigProfileDelete([]string{"default"})
+	err := RunInternalConfigProfileDelete("default")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
 
@@ -64,31 +46,8 @@ func Test_RunInternalConfigProfileDelete_ActiveProfile(t *testing.T) {
 func Example_runInternalConfigProfileDelete() {
 	testutils_viper.InitVipers(&testing.T{})
 
-	_ = RunInternalConfigProfileDelete([]string{"production"})
+	_ = RunInternalConfigProfileDelete("production")
 
 	// Output:
 	// Profile 'production' deleted successfully - Success
-}
-
-// Test parseDeleteArgs function with no args
-func Test_parseDeleteArgs_NoArgs(t *testing.T) {
-	expectedErrorPattern := "^profile name is required$"
-	_, err := parseDeleteArgs([]string{})
-	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test parseDeleteArgs function with multiple args
-func Test_parseDeleteArgs_MultipleArgs(t *testing.T) {
-	_, err := parseDeleteArgs([]string{"production", "extra-arg"})
-	testutils.CheckExpectedError(t, err, nil)
-}
-
-// Test parseDeleteArgs function with one arg
-func Test_parseDeleteArgs_OneArg(t *testing.T) {
-	parsedArg, err := parseDeleteArgs([]string{"production"})
-	testutils.CheckExpectedError(t, err, nil)
-
-	if parsedArg != "production" {
-		t.Fatalf("Expected parsedArg to be 'production', got '%s'", parsedArg)
-	}
 }

--- a/internal/commands/config/profile/describe_internal.go
+++ b/internal/commands/config/profile/describe_internal.go
@@ -2,18 +2,12 @@ package profile_internal
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pingidentity/pingctl/internal/output"
 	"github.com/pingidentity/pingctl/internal/profiles"
 )
 
-func RunInternalConfigProfileDescribe(args []string) error {
-	pName, err := parseDescArgs(args)
-	if err != nil {
-		return fmt.Errorf("failed to describe profile: %v", err)
-	}
-
+func RunInternalConfigProfileDescribe(pName string) (err error) {
 	err = profiles.ValidateExistingProfileName(pName)
 	if err != nil {
 		return fmt.Errorf("failed to describe profile: %v", err)
@@ -56,19 +50,4 @@ func RunInternalConfigProfileDescribe(args []string) error {
 	})
 
 	return nil
-}
-
-func parseDescArgs(args []string) (string, error) {
-	if len(args) == 0 {
-		return "", fmt.Errorf("profile name is required")
-	}
-
-	if len(args) > 1 {
-		output.Print(output.Opts{
-			Message: fmt.Sprintf("'pingctl config profile describe' takes only one argument. Ignoring extra arguments: %s", strings.Join(args[1:], " ")),
-			Result:  output.ENUM_RESULT_NOACTION_WARN,
-		})
-	}
-
-	return args[0], nil
 }

--- a/internal/commands/config/profile/describe_internal_test.go
+++ b/internal/commands/config/profile/describe_internal_test.go
@@ -7,28 +7,11 @@ import (
 	"github.com/pingidentity/pingctl/internal/testing/testutils_viper"
 )
 
-// Test RunInternalConfigProfileDescribe function with no args
-func Test_RunInternalConfigProfileDescribe_NoArgs(t *testing.T) {
+// Test RunInternalConfigProfileDescribe function with valid arg
+func Test_RunInternalConfigProfileDescribe_ValidArg(t *testing.T) {
 	testutils_viper.InitVipers(t)
 
-	expectedErrorPattern := "^failed to describe profile: profile name is required$"
-	err := RunInternalConfigProfileDescribe([]string{})
-	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test RunInternalConfigProfileDescribe function with multiple args
-func Test_RunInternalConfigProfileDescribe_MultipleArgs(t *testing.T) {
-	testutils_viper.InitVipers(t)
-
-	err := RunInternalConfigProfileDescribe([]string{"production", "extra-arg"})
-	testutils.CheckExpectedError(t, err, nil)
-}
-
-// Test RunInternalConfigProfileDescribe function with valid args
-func Test_RunInternalConfigProfileDescribe_ValidArgs(t *testing.T) {
-	testutils_viper.InitVipers(t)
-
-	err := RunInternalConfigProfileDescribe([]string{"production"})
+	err := RunInternalConfigProfileDescribe("production")
 	testutils.CheckExpectedError(t, err, nil)
 }
 
@@ -37,7 +20,7 @@ func Test_RunInternalConfigProfileDescribe_InvalidProfileName(t *testing.T) {
 	testutils_viper.InitVipers(t)
 
 	expectedErrorPattern := "^failed to describe profile: invalid profile name: '.*'. name must contain only alphanumeric characters, underscores, and dashes$"
-	err := RunInternalConfigProfileDescribe([]string{"invalid&*^*&"})
+	err := RunInternalConfigProfileDescribe("invalid&*^*&")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
 
@@ -46,7 +29,7 @@ func Test_RunInternalConfigProfileDescribe_NonExistentProfile(t *testing.T) {
 	testutils_viper.InitVipers(t)
 
 	expectedErrorPattern := "^failed to describe profile: invalid profile name: '.*' profile does not exist$"
-	err := RunInternalConfigProfileDescribe([]string{"invalid"})
+	err := RunInternalConfigProfileDescribe("invalid")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
 
@@ -54,7 +37,7 @@ func Test_RunInternalConfigProfileDescribe_NonExistentProfile(t *testing.T) {
 func Test_RunInternalConfigProfileDescribe_ActiveProfile(t *testing.T) {
 	testutils_viper.InitVipers(t)
 
-	err := RunInternalConfigProfileDescribe([]string{"default"})
+	err := RunInternalConfigProfileDescribe("default")
 	testutils.CheckExpectedError(t, err, nil)
 }
 
@@ -62,14 +45,14 @@ func Test_RunInternalConfigProfileDescribe_ActiveProfile(t *testing.T) {
 func Example_runInternalConfigProfileDescribe() {
 	testutils_viper.InitVipers(&testing.T{})
 
-	_ = RunInternalConfigProfileDescribe([]string{"production"})
+	_ = RunInternalConfigProfileDescribe("production")
 
 	// Output:
 	// Profile Name: production
 	// Description: test profile description
 	//
 	// Set Options:
-	//  - pingctl.output: text
+	//  - pingctl.outputFormat: text
 	//  - pingctl.color: true
 	//
 	// Unset Options:
@@ -78,27 +61,4 @@ func Example_runInternalConfigProfileDescribe() {
 	//  - pingone.worker.clientID
 	//  - pingone.worker.clientSecret
 	//  - pingone.region
-}
-
-// Test parseDescArgs function with no args
-func Test_parseDescArgs_NoArgs(t *testing.T) {
-	expectedErrorPattern := "^profile name is required$"
-	_, err := parseDescArgs([]string{})
-	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test parseDescArgs function with multiple args
-func Test_parseDescArgs_MultipleArgs(t *testing.T) {
-	_, err := parseDescArgs([]string{"production", "extra-arg"})
-	testutils.CheckExpectedError(t, err, nil)
-}
-
-// Test parseDescArgs function with one arg
-func Test_parseDescArgs_OneArg(t *testing.T) {
-	parsedArg, err := parseDescArgs([]string{"production"})
-	testutils.CheckExpectedError(t, err, nil)
-
-	if parsedArg != "production" {
-		t.Fatalf("Expected parsed arg to be 'production', got '%s'", parsedArg)
-	}
 }

--- a/internal/commands/config/profile/list_internal.go
+++ b/internal/commands/config/profile/list_internal.go
@@ -2,20 +2,12 @@ package profile_internal
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pingidentity/pingctl/internal/output"
 	"github.com/pingidentity/pingctl/internal/profiles"
 )
 
-func RunInternalConfigProfileList(args []string) {
-	if len(args) > 0 {
-		output.Print(output.Opts{
-			Message: fmt.Sprintf("'pingctl config profile list' does not take additional arguments. Ignoring extra arguments: %s", strings.Join(args, " ")),
-			Result:  output.ENUM_RESULT_NOACTION_WARN,
-		})
-	}
-
+func RunInternalConfigProfileList() {
 	activeProfileName := profiles.GetConfigActiveProfile()
 	profileNames := profiles.ConfigProfileNames()
 	listOutputString := "pingctl profiles:\n"

--- a/internal/commands/config/profile/list_internal_test.go
+++ b/internal/commands/config/profile/list_internal_test.go
@@ -6,26 +6,13 @@ import (
 	"github.com/pingidentity/pingctl/internal/testing/testutils_viper"
 )
 
-// Test RunInternalConfigProfileList function with no args
-func Example_runInternalConfigProfileList_noArgs() {
+// Test RunInternalConfigProfileList function
+func Example_runInternalConfigProfileList() {
 	testutils_viper.InitVipers(&testing.T{})
 
-	RunInternalConfigProfileList([]string{})
+	RunInternalConfigProfileList()
 
 	// Output:
-	// pingctl profiles:
-	//   * default
-	//     production
-}
-
-// Test RunInternalConfigProfileList function with args
-func Example_runInternalConfigProfileList_withArgs() {
-	testutils_viper.InitVipers(&testing.T{})
-
-	RunInternalConfigProfileList([]string{"arg1", "arg2"})
-
-	// Output:
-	// 'pingctl config profile list' does not take additional arguments. Ignoring extra arguments: arg1 arg2 - No Action (Warning)
 	// pingctl profiles:
 	//   * default
 	//     production

--- a/internal/commands/config/profile/set_active_internal.go
+++ b/internal/commands/config/profile/set_active_internal.go
@@ -2,18 +2,12 @@ package profile_internal
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pingidentity/pingctl/internal/output"
 	"github.com/pingidentity/pingctl/internal/profiles"
 )
 
-func RunInternalConfigProfileSetActive(args []string) error {
-	profileName, err := parseSetActiveArgs(args)
-	if err != nil {
-		return fmt.Errorf("failed to set active profile: %v", err)
-	}
-
+func RunInternalConfigProfileSetActive(profileName string) (err error) {
 	if err = profiles.ValidateExistingProfileName(profileName); err != nil {
 		return fmt.Errorf("failed to set active profile: %v", err)
 	}
@@ -28,21 +22,4 @@ func RunInternalConfigProfileSetActive(args []string) error {
 	})
 
 	return nil
-}
-
-func parseSetActiveArgs(args []string) (string, error) {
-	if len(args) == 0 {
-		return "", fmt.Errorf("profile name is required")
-	}
-
-	if len(args) > 1 {
-		output.Print(output.Opts{
-			Message: fmt.Sprintf("'pingctl config profile set-active' only sets one profile as active per command. Ignoring extra arguments: %s", strings.Join(args[1:], " ")),
-			Result:  output.ENUM_RESULT_NOACTION_WARN,
-		})
-	}
-
-	profileName := args[0]
-
-	return profileName, nil
 }

--- a/internal/commands/config/profile/set_active_internal_test.go
+++ b/internal/commands/config/profile/set_active_internal_test.go
@@ -7,28 +7,11 @@ import (
 	"github.com/pingidentity/pingctl/internal/testing/testutils_viper"
 )
 
-// Test RunInternalConfigProfileSetActive function with no args
-func Test_RunInternalConfigProfileSetActive_NoArgs(t *testing.T) {
-	testutils_viper.InitVipers(t)
-
-	expectedErrorPattern := "^failed to set active profile: profile name is required$"
-	err := RunInternalConfigProfileSetActive([]string{})
-	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test RunInternalConfigProfileSetActive function with multiple args
-func Test_RunInternalConfigProfileSetActive_MultipleArgs(t *testing.T) {
-	testutils_viper.InitVipers(t)
-
-	err := RunInternalConfigProfileSetActive([]string{"production", "extra-arg"})
-	testutils.CheckExpectedError(t, err, nil)
-}
-
 // Test RunInternalConfigProfileSetActive function with valid args
 func Test_RunInternalConfigProfileSetActive_ValidArgs(t *testing.T) {
 	testutils_viper.InitVipers(t)
 
-	err := RunInternalConfigProfileSetActive([]string{"production"})
+	err := RunInternalConfigProfileSetActive("production")
 	testutils.CheckExpectedError(t, err, nil)
 }
 
@@ -37,7 +20,7 @@ func Test_RunInternalConfigProfileSetActive_InvalidProfileName(t *testing.T) {
 	testutils_viper.InitVipers(t)
 
 	expectedErrorPattern := "^failed to set active profile: invalid profile name: '.*'. name must contain only alphanumeric characters, underscores, and dashes$"
-	err := RunInternalConfigProfileSetActive([]string{"invalid&*^*&"})
+	err := RunInternalConfigProfileSetActive("invalid&*^*&")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
 
@@ -46,7 +29,7 @@ func Test_RunInternalConfigProfileSetActive_NonExistentProfile(t *testing.T) {
 	testutils_viper.InitVipers(t)
 
 	expectedErrorPattern := "^failed to set active profile: invalid profile name: '.*' profile does not exist$"
-	err := RunInternalConfigProfileSetActive([]string{"invalid"})
+	err := RunInternalConfigProfileSetActive("invalid")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
 
@@ -54,38 +37,15 @@ func Test_RunInternalConfigProfileSetActive_NonExistentProfile(t *testing.T) {
 func Test_RunInternalConfigProfileSetActive_ActiveProfile(t *testing.T) {
 	testutils_viper.InitVipers(t)
 
-	err := RunInternalConfigProfileSetActive([]string{"default"})
+	err := RunInternalConfigProfileSetActive("default")
 	testutils.CheckExpectedError(t, err, nil)
 }
 
 func Example_runInternalConfigProfileSetActive() {
 	testutils_viper.InitVipers(&testing.T{})
 
-	_ = RunInternalConfigProfileSetActive([]string{"production"})
+	_ = RunInternalConfigProfileSetActive("production")
 
 	// Output:
 	// Active configuration profile set to 'production' - Success
-}
-
-// Test parseSetActiveArgs function with no args
-func Test_parseSetActiveArgs_NoArgs(t *testing.T) {
-	expectedErrorPattern := "^profile name is required$"
-	_, err := parseSetActiveArgs([]string{})
-	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test parseSetActiveArgs function with multiple args
-func Test_parseSetActiveArgs_MultipleArgs(t *testing.T) {
-	_, err := parseSetActiveArgs([]string{"production", "extra-arg"})
-	testutils.CheckExpectedError(t, err, nil)
-}
-
-// Test parseSetActiveArgs function with one arg
-func Test_parseSetActiveArgs_OneArg(t *testing.T) {
-	parsedArg, err := parseSetActiveArgs([]string{"production"})
-	testutils.CheckExpectedError(t, err, nil)
-
-	if parsedArg != "production" {
-		t.Fatalf("Expected profile name to be 'production', got '%s'", parsedArg)
-	}
 }

--- a/internal/commands/config/set_internal.go
+++ b/internal/commands/config/set_internal.go
@@ -8,13 +8,12 @@ import (
 
 	"github.com/hashicorp/go-uuid"
 	"github.com/pingidentity/pingctl/internal/customtypes"
-	"github.com/pingidentity/pingctl/internal/output"
 	"github.com/pingidentity/pingctl/internal/profiles"
 )
 
-func RunInternalConfigSet(args []string) error {
+func RunInternalConfigSet(kvPair string) error {
 	// Parse the key=value pair from the command line arguments
-	viperKey, value, err := parseSetArgs(args)
+	viperKey, value, err := parseKeyValuePair(kvPair)
 	if err != nil {
 		return err
 	}
@@ -54,22 +53,10 @@ func RunInternalConfigSet(args []string) error {
 	return nil
 }
 
-func parseSetArgs(args []string) (string, string, error) {
-	if len(args) == 0 {
-		return "", "", fmt.Errorf("failed to set configuration: no 'key=value' assignment given in set command")
-	}
-
-	if len(args) > 1 {
-		output.Print(output.Opts{
-			Message: fmt.Sprintf("'pingctl config set' only sets one key-value pair per command. Ignoring extra arguments: %s", strings.Join(args[1:], " ")),
-			Result:  output.ENUM_RESULT_NOACTION_WARN,
-		})
-	}
-
-	// Assume viper configuration key=value pair is args[0] and ignore any other input
-	parsedInput := strings.SplitN(args[0], "=", 2)
+func parseKeyValuePair(kvPair string) (string, string, error) {
+	parsedInput := strings.SplitN(kvPair, "=", 2)
 	if len(parsedInput) != 2 {
-		return "", "", fmt.Errorf("failed to set configuration: invalid assignment format '%s'. Expect 'key=value' format", args[0])
+		return "", "", fmt.Errorf("failed to set configuration: invalid assignment format '%s'. Expect 'key=value' format", kvPair)
 	}
 
 	return parsedInput[0], parsedInput[1], nil

--- a/internal/commands/config/set_internal_test.go
+++ b/internal/commands/config/set_internal_test.go
@@ -4,90 +4,51 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/pingidentity/pingctl/internal/profiles"
 	"github.com/pingidentity/pingctl/internal/testing/testutils"
 	"github.com/pingidentity/pingctl/internal/testing/testutils_viper"
 )
 
-// Test RunInternalConfigSet function
-func Test_RunInternalConfigSet_NoArgs(t *testing.T) {
-	expectedErrorPattern := `^failed to set configuration: no 'key=value' assignment given in set command$`
-	err := RunInternalConfigSet([]string{})
-	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
 // Test RunInternalConfigSet function with args
 func Test_RunInternalConfigSet_WithArgs(t *testing.T) {
 	testutils_viper.InitVipers(t)
 
-	uuid := "12345678-1234-1234-1234-123456789012"
-	err := RunInternalConfigSet([]string{fmt.Sprintf("%s=%s", profiles.WorkerClientIDOption.ViperKey, uuid)})
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatalf("failed to generate UUID: %v", err)
+	}
+
+	err = RunInternalConfigSet(fmt.Sprintf("%s=%s", profiles.WorkerClientIDOption.ViperKey, uuid))
 	testutils.CheckExpectedError(t, err, nil)
 }
 
 // Test RunInternalConfigSet function with invalid key
 func Test_RunInternalConfigSet_InvalidKey(t *testing.T) {
 	expectedErrorPattern := `^failed to set configuration: key 'pingctl\.invalid' is not recognized as a valid configuration key\. Valid keys: [A-Za-z\.\s,]+$`
-	err := RunInternalConfigSet([]string{"pingctl.invalid=true"})
+	err := RunInternalConfigSet("pingctl.invalid=true")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test RunInternalConfigSet function with too many args
-func Test_RunInternalConfigSet_TooManyArgs(t *testing.T) {
-	testutils_viper.InitVipers(t)
-
-	uuid := "12345678-1234-1234-1234-123456789012"
-	err := RunInternalConfigSet([]string{fmt.Sprintf("%s=%s", profiles.WorkerClientIDOption.ViperKey, uuid), fmt.Sprintf("%s=%s", profiles.WorkerEnvironmentIDOption.ViperKey, uuid)})
-	testutils.CheckExpectedError(t, err, nil)
 }
 
 // Test RunInternalConfigSet function with empty value
 func Test_RunInternalConfigSet_EmptyValue(t *testing.T) {
 	expectedErrorPattern := `^failed to set configuration: value for key 'pingone\.worker\.clientID' is empty\. Use 'pingctl config unset pingone\.worker\.clientID' to unset the key$`
-	err := RunInternalConfigSet([]string{fmt.Sprintf("%s=", profiles.WorkerClientIDOption.ViperKey)})
+	err := RunInternalConfigSet(fmt.Sprintf("%s=", profiles.WorkerClientIDOption.ViperKey))
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
 
 // Test RunInternalConfigSet function with invalid value
 func Test_RunInternalConfigSet_InvalidValue(t *testing.T) {
 	expectedErrorPattern := `^failed to set configuration: value for key 'pingone\.worker\.clientID' must be a valid UUID$`
-	err := RunInternalConfigSet([]string{fmt.Sprintf("%s=invalid", profiles.WorkerClientIDOption.ViperKey)})
+	err := RunInternalConfigSet(fmt.Sprintf("%s=invalid", profiles.WorkerClientIDOption.ViperKey))
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
 
 // Test RunInternalConfigSet function with invalid value type
 func Test_RunInternalConfigSet_InvalidValueType(t *testing.T) {
 	expectedErrorPattern := `^failed to set configuration: value for key 'pingctl\.color' must be a boolean. Use 'true' or 'false'$`
-	err := RunInternalConfigSet([]string{fmt.Sprintf("%s=notboolean", profiles.ColorOption.ViperKey)})
+	err := RunInternalConfigSet(fmt.Sprintf("%s=notboolean", profiles.ColorOption.ViperKey))
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test parseSetArgs() function with no args
-func Test_parseSetArgs_NoArgs(t *testing.T) {
-	expectedErrorPattern := `^failed to set configuration: no 'key=value' assignment given in set command$`
-	_, _, err := parseSetArgs([]string{})
-	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test parseSetArgs() function with invalid assignment format
-func Test_parseSetArgs_InvalidAssignmentFormat(t *testing.T) {
-	expectedErrorPattern := `^failed to set configuration: invalid assignment format 'pingone\.worker\.clientID'. Expect 'key=value' format$`
-	_, _, err := parseSetArgs([]string{profiles.WorkerClientIDOption.ViperKey})
-	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test parseSetArgs() function with valid assignment format
-func Test_parseSetArgs_ValidAssignmentFormat(t *testing.T) {
-	uuid := "12345678-1234-1234-1234-123456789012"
-	_, _, err := parseSetArgs([]string{fmt.Sprintf("%s=%s", profiles.WorkerClientIDOption.ViperKey, uuid)})
-	testutils.CheckExpectedError(t, err, nil)
-}
-
-// Test parseSetArgs() function with too many args
-func Test_parseSetArgs_TooManyArgs(t *testing.T) {
-	uuid := "12345678-1234-1234-1234-123456789012"
-	_, _, err := parseSetArgs([]string{fmt.Sprintf("%s=%s", profiles.WorkerClientIDOption.ViperKey, uuid), fmt.Sprintf("%s=%s", profiles.WorkerEnvironmentIDOption.ViperKey, uuid)})
-	testutils.CheckExpectedError(t, err, nil)
 }
 
 // Test setValue() function with valid value
@@ -131,7 +92,12 @@ func Test_setBool_InvalidValue(t *testing.T) {
 func Test_setUUID_ValidValue(t *testing.T) {
 	testutils_viper.InitVipers(t)
 
-	err := setUUID(profiles.WorkerClientIDOption.ViperKey, "12345678-1234-1234-1234-123456789012")
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatalf("failed to generate UUID: %v", err)
+	}
+
+	err = setUUID(profiles.WorkerClientIDOption.ViperKey, uuid)
 	testutils.CheckExpectedError(t, err, nil)
 }
 

--- a/internal/commands/config/unset_internal.go
+++ b/internal/commands/config/unset_internal.go
@@ -5,17 +5,10 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/pingidentity/pingctl/internal/output"
 	"github.com/pingidentity/pingctl/internal/profiles"
 )
 
-func RunInternalConfigUnset(args []string) error {
-	// Parse the viper key from the command line arguments
-	viperKey, err := parseUnsetArgs(args)
-	if err != nil {
-		return err
-	}
-
+func RunInternalConfigUnset(viperKey string) error {
 	// Check if the key is a valid viper configuration key
 	validKeys := profiles.ProfileKeys()
 	if !slices.ContainsFunc(validKeys, func(v string) bool {
@@ -42,20 +35,4 @@ func RunInternalConfigUnset(args []string) error {
 	}
 
 	return nil
-}
-
-func parseUnsetArgs(args []string) (string, error) {
-	if len(args) == 0 {
-		return "", fmt.Errorf("unable to unset configuration: no key given in unset command")
-	}
-
-	if len(args) > 1 {
-		output.Print(output.Opts{
-			Message: fmt.Sprintf("'pingctl config unset' can only unset one key per command. Ignoring extra arguments: %s", strings.Join(args[1:], " ")),
-			Result:  output.ENUM_RESULT_NOACTION_WARN,
-		})
-	}
-
-	// Assume viper configuration key is args[0] and ignore any other input
-	return args[0], nil
 }

--- a/internal/commands/config/unset_internal_test.go
+++ b/internal/commands/config/unset_internal_test.go
@@ -8,17 +8,10 @@ import (
 	"github.com/pingidentity/pingctl/internal/testing/testutils_viper"
 )
 
-// Test RunInternalConfigUnset function with empty args
-func Test_RunInternalConfigUnset_EmptyArgs(t *testing.T) {
-	expectedErrorPattern := `^unable to unset configuration: no key given in unset command$`
-	err := RunInternalConfigUnset([]string{})
-	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
 // Test RunInternalConfigUnset function with invalid key
 func Test_RunInternalConfigUnset_InvalidKey(t *testing.T) {
 	expectedErrorPattern := `^unable to unset configuration: key 'pingctl\.invalid' is not recognized as a valid configuration key\. Valid keys: [A-Za-z\.\s,]+$`
-	err := RunInternalConfigUnset([]string{"pingctl.invalid"})
+	err := RunInternalConfigUnset("pingctl.invalid")
 	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
 }
 
@@ -26,33 +19,6 @@ func Test_RunInternalConfigUnset_InvalidKey(t *testing.T) {
 func Test_RunInternalConfigUnset_ValidKey(t *testing.T) {
 	testutils_viper.InitVipers(t)
 
-	err := RunInternalConfigUnset([]string{profiles.ColorOption.ViperKey})
-	testutils.CheckExpectedError(t, err, nil)
-}
-
-// Test RunInternalConfigUnset function with too many args
-func Test_RunInternalConfigUnset_TooManyArgs(t *testing.T) {
-	testutils_viper.InitVipers(t)
-
-	err := RunInternalConfigUnset([]string{profiles.ColorOption.ViperKey, profiles.WorkerClientIDOption.ViperKey})
-	testutils.CheckExpectedError(t, err, nil)
-}
-
-// Test parseUnsetArgs function with empty args
-func Test_parseUnsetArgs_EmptyArgs(t *testing.T) {
-	expectedErrorPattern := `^unable to unset configuration: no key given in unset command$`
-	_, err := parseUnsetArgs([]string{})
-	testutils.CheckExpectedError(t, err, &expectedErrorPattern)
-}
-
-// Test parseUnsetArgs function with valid args
-func Test_parseUnsetArgs_ValidArgs(t *testing.T) {
-	_, err := parseUnsetArgs([]string{profiles.ColorOption.ViperKey})
-	testutils.CheckExpectedError(t, err, nil)
-}
-
-// Test parseUnsetArgs function with too many args
-func Test_parseUnsetArgs_TooManyArgs(t *testing.T) {
-	_, err := parseUnsetArgs([]string{profiles.ColorOption.ViperKey, profiles.WorkerClientIDOption.ViperKey})
+	err := RunInternalConfigUnset(profiles.ColorOption.ViperKey)
 	testutils.CheckExpectedError(t, err, nil)
 }

--- a/internal/profiles/types.go
+++ b/internal/profiles/types.go
@@ -31,9 +31,9 @@ const (
 
 var (
 	OutputOption = Option{
-		CobraParamName: "output",
-		ViperKey:       "pingctl.output",
-		EnvVar:         "PINGCTL_OUTPUT",
+		CobraParamName: "output-format",
+		ViperKey:       "pingctl.outputFormat",
+		EnvVar:         "PINGCTL_OUTPUT_FORMAT",
 		Type:           ENUM_OUTPUT_FORMAT,
 	}
 	ColorOption = Option{
@@ -43,7 +43,7 @@ var (
 		Type:           ENUM_BOOL,
 	}
 	ProfileOption = Option{
-		CobraParamName: "profile",
+		CobraParamName: "active-profile",
 		ViperKey:       "activeProfile",
 		EnvVar:         "PINGCTL_ACTIVE_PROFILE",
 		Type:           ENUM_STRING,

--- a/internal/testing/testutils_viper/viper_utils.go
+++ b/internal/testing/testutils_viper/viper_utils.go
@@ -16,7 +16,7 @@ default:
     description: "default description"
     pingctl:
         color: true
-        output: text
+        outputFormat: text
     pingone:
         export:
             environmentid: ""
@@ -29,7 +29,7 @@ production:
     description: "test profile description"
     pingctl:
         color: true
-        output: text
+        outputFormat: text
     pingone:
         export:
             environmentid: ""


### PR DESCRIPTION
- Update Cobra.Command initializations with Args to define expected arguments per command, DisableFlagsInUseLine to write our own Usage message, and Use to more clearly communicate how to use each command.
- Add cmd/common/cobra_utils.go to handle common cobra functions such as ExactArgs and RangeArgs for the command Args attribute.
- Simplify away internal command arg parsing logic, now that the cobra command handles this directly.
- Update testing to handle the logic simplification and test the new argument restrictions per command.
- Add shorthand flag characters to most command flags where useful.