### PR TITLE
PDI-1813: Export block HCL generation for PingFederate

### DIFF
--- a/internal/connector/pingfederate/pingfederate_connector.go
+++ b/internal/connector/pingfederate/pingfederate_connector.go
@@ -59,6 +59,7 @@ func (c *PingfederateConnector) Export(format, outputDir string, overwriteExport
 		resources.NotificationPublishersSettings(&c.clientInfo),
 		resources.OAuthAccessTokenManager(&c.clientInfo),
 		resources.OAuthAccessTokenMapping(&c.clientInfo),
+		resources.OAuthCIBAServerPolicySettings(&c.clientInfo),
 	}
 
 	return common.WriteFiles(exportableResources, format, outputDir, overwriteExport)

--- a/internal/connector/pingfederate/pingfederate_connector.go
+++ b/internal/connector/pingfederate/pingfederate_connector.go
@@ -56,6 +56,7 @@ func (c *PingfederateConnector) Export(format, outputDir string, overwriteExport
 		resources.IncomingProxySettings(&c.clientInfo),
 		resources.KerberosRealm(&c.clientInfo),
 		resources.LocalIdentityIdentityProfile(&c.clientInfo),
+		resources.NotificationPublishersSettings(&c.clientInfo),
 	}
 
 	return common.WriteFiles(exportableResources, format, outputDir, overwriteExport)

--- a/internal/connector/pingfederate/pingfederate_connector.go
+++ b/internal/connector/pingfederate/pingfederate_connector.go
@@ -57,6 +57,7 @@ func (c *PingfederateConnector) Export(format, outputDir string, overwriteExport
 		resources.KerberosRealm(&c.clientInfo),
 		resources.LocalIdentityIdentityProfile(&c.clientInfo),
 		resources.NotificationPublishersSettings(&c.clientInfo),
+		resources.OAuthAccessTokenManager(&c.clientInfo),
 	}
 
 	return common.WriteFiles(exportableResources, format, outputDir, overwriteExport)

--- a/internal/connector/pingfederate/pingfederate_connector.go
+++ b/internal/connector/pingfederate/pingfederate_connector.go
@@ -58,6 +58,7 @@ func (c *PingfederateConnector) Export(format, outputDir string, overwriteExport
 		resources.LocalIdentityIdentityProfile(&c.clientInfo),
 		resources.NotificationPublishersSettings(&c.clientInfo),
 		resources.OAuthAccessTokenManager(&c.clientInfo),
+		resources.OAuthAccessTokenMapping(&c.clientInfo),
 	}
 
 	return common.WriteFiles(exportableResources, format, outputDir, overwriteExport)

--- a/internal/connector/pingfederate/pingfederate_connector.go
+++ b/internal/connector/pingfederate/pingfederate_connector.go
@@ -60,6 +60,7 @@ func (c *PingfederateConnector) Export(format, outputDir string, overwriteExport
 		resources.OAuthAccessTokenManager(&c.clientInfo),
 		resources.OAuthAccessTokenMapping(&c.clientInfo),
 		resources.OAuthCIBAServerPolicySettings(&c.clientInfo),
+		resources.OAuthClient(&c.clientInfo),
 	}
 
 	return common.WriteFiles(exportableResources, format, outputDir, overwriteExport)

--- a/internal/connector/pingfederate/pingfederate_connector_test.go
+++ b/internal/connector/pingfederate/pingfederate_connector_test.go
@@ -145,6 +145,11 @@ func TestPingFederateTerraformPlan(t *testing.T) {
 				"Error: Request cancelled",
 			},
 		},
+		{
+			name:          "PingFederateOAuthCIBAServerPolicySettings",
+			resource:      resources.OAuthCIBAServerPolicySettings(PingFederateClientInfo),
+			ignoredErrors: nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/connector/pingfederate/pingfederate_connector_test.go
+++ b/internal/connector/pingfederate/pingfederate_connector_test.go
@@ -124,6 +124,14 @@ func TestPingFederateTerraformPlan(t *testing.T) {
 			resource:      resources.LocalIdentityIdentityProfile(PingFederateClientInfo),
 			ignoredErrors: nil,
 		},
+		{
+			name:     "PingFederateNotificationPublishersSettings",
+			resource: resources.NotificationPublishersSettings(PingFederateClientInfo),
+			ignoredErrors: []string{
+				"Error: Plugin did not respond",
+				"Error: Request cancelled",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/connector/pingfederate/pingfederate_connector_test.go
+++ b/internal/connector/pingfederate/pingfederate_connector_test.go
@@ -137,6 +137,14 @@ func TestPingFederateTerraformPlan(t *testing.T) {
 			resource:      resources.OAuthAccessTokenManager(PingFederateClientInfo),
 			ignoredErrors: nil,
 		},
+		{
+			name:     "PingFederateOAuthAccessTokenMapping",
+			resource: resources.OAuthAccessTokenMapping(PingFederateClientInfo),
+			ignoredErrors: []string{
+				"Error: Plugin did not respond",
+				"Error: Request cancelled",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/connector/pingfederate/pingfederate_connector_test.go
+++ b/internal/connector/pingfederate/pingfederate_connector_test.go
@@ -150,6 +150,15 @@ func TestPingFederateTerraformPlan(t *testing.T) {
 			resource:      resources.OAuthCIBAServerPolicySettings(PingFederateClientInfo),
 			ignoredErrors: nil,
 		},
+		{
+			name:     "PingFederateOAuthClient",
+			resource: resources.OAuthClient(PingFederateClientInfo),
+			ignoredErrors: []string{
+				"Error: persistent_grant_expiration_type must be configured to \"OVERRIDE_SERVER_DEFAULT\" to modify the other persistent_grant_expiration values.",
+				"Error: client_auth.secret cannot be empty when \"CLIENT_CREDENTIALS\" is included in grant_types.",
+				"Error: Invalid Attribute Value",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/connector/pingfederate/pingfederate_connector_test.go
+++ b/internal/connector/pingfederate/pingfederate_connector_test.go
@@ -132,6 +132,11 @@ func TestPingFederateTerraformPlan(t *testing.T) {
 				"Error: Request cancelled",
 			},
 		},
+		{
+			name:          "PingFederateOAuthAccessTokenManager",
+			resource:      resources.OAuthAccessTokenManager(PingFederateClientInfo),
+			ignoredErrors: nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/connector/pingfederate/resources/pingfederate_notification_publishers_settings.go
+++ b/internal/connector/pingfederate/resources/pingfederate_notification_publishers_settings.go
@@ -1,0 +1,52 @@
+package resources
+
+import (
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/common"
+	"github.com/pingidentity/pingctl/internal/logger"
+)
+
+// Verify that the resource satisfies the exportable resource interface
+var (
+	_ connector.ExportableResource = &PingFederateNotificationPublishersSettingsResource{}
+)
+
+type PingFederateNotificationPublishersSettingsResource struct {
+	clientInfo *connector.PingFederateClientInfo
+}
+
+// Utility method for creating a PingFederateNotificationPublishersSettingsResource
+func NotificationPublishersSettings(clientInfo *connector.PingFederateClientInfo) *PingFederateNotificationPublishersSettingsResource {
+	return &PingFederateNotificationPublishersSettingsResource{
+		clientInfo: clientInfo,
+	}
+}
+
+func (r *PingFederateNotificationPublishersSettingsResource) ExportAll() (*[]connector.ImportBlock, error) {
+	l := logger.Get()
+
+	importBlocks := []connector.ImportBlock{}
+
+	l.Debug().Msgf("Generating Import Blocks for all %s resources...", r.ResourceType())
+
+	notificationPublishersSettingsId := "notification_publishers_settings_singleton_id"
+	notificationPublishersSettingsName := "Notification Publishers Settings"
+
+	commentData := map[string]string{
+		"Resource Type": r.ResourceType(),
+		"Singleton ID":  common.SINGLETON_ID_COMMENT_DATA,
+	}
+
+	importBlocks = append(importBlocks, connector.ImportBlock{
+		ResourceType:       r.ResourceType(),
+		ResourceName:       notificationPublishersSettingsName,
+		ResourceID:         notificationPublishersSettingsId,
+		CommentInformation: common.GenerateCommentInformation(commentData),
+	})
+
+	return &importBlocks, nil
+}
+
+func (r *PingFederateNotificationPublishersSettingsResource) ResourceType() string {
+	return "pingfederate_notification_publishers_settings"
+}

--- a/internal/connector/pingfederate/resources/pingfederate_notification_publishers_settings_test.go
+++ b/internal/connector/pingfederate/resources/pingfederate_notification_publishers_settings_test.go
@@ -1,0 +1,26 @@
+package resources_test
+
+import (
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingfederate/resources"
+	"github.com/pingidentity/pingctl/internal/testing/testutils"
+)
+
+func TestPingFederateNotificationPublishersSettingsExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	PingFederateClientInfo := testutils.GetPingFederateClientInfo(t)
+	resource := resources.NotificationPublishersSettings(PingFederateClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingfederate_notification_publishers_settings",
+			ResourceName: "Notification Publishers Settings",
+			ResourceID:   "notification_publishers_settings_singleton_id",
+		},
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
+}

--- a/internal/connector/pingfederate/resources/pingfederate_oauth_access_token_manager.go
+++ b/internal/connector/pingfederate/resources/pingfederate_oauth_access_token_manager.go
@@ -1,0 +1,84 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/common"
+	"github.com/pingidentity/pingctl/internal/logger"
+)
+
+// Verify that the resource satisfies the exportable resource interface
+var (
+	_ connector.ExportableResource = &PingFederateOAuthAccessTokenManagerResource{}
+)
+
+type PingFederateOAuthAccessTokenManagerResource struct {
+	clientInfo *connector.PingFederateClientInfo
+}
+
+// Utility method for creating a PingFederateOAuthAccessTokenManagerResource
+func OAuthAccessTokenManager(clientInfo *connector.PingFederateClientInfo) *PingFederateOAuthAccessTokenManagerResource {
+	return &PingFederateOAuthAccessTokenManagerResource{
+		clientInfo: clientInfo,
+	}
+}
+
+func (r *PingFederateOAuthAccessTokenManagerResource) ExportAll() (*[]connector.ImportBlock, error) {
+	l := logger.Get()
+
+	l.Debug().Msgf("Fetching all %s resources...", r.ResourceType())
+
+	apiExecuteFunc := r.clientInfo.ApiClient.OauthAccessTokenManagersAPI.GetTokenManagers(r.clientInfo.Context).Execute
+	apiFunctionName := "GetTokenManagers"
+
+	accessTokenManagers, response, err := apiExecuteFunc()
+
+	err = common.HandleClientResponse(response, err, apiFunctionName, r.ResourceType())
+	if err != nil {
+		return nil, err
+	}
+
+	if accessTokenManagers == nil {
+		l.Error().Msgf("Returned %s() accessTokenManagers is nil.", apiFunctionName)
+		l.Error().Msgf("%s Response Code: %s\nResponse Body: %s", apiFunctionName, response.Status, response.Body)
+		return nil, fmt.Errorf("failed to fetch %s resources via %s()", r.ResourceType(), apiFunctionName)
+	}
+
+	accessTokenManagersItems, ok := accessTokenManagers.GetItemsOk()
+	if !ok {
+		l.Error().Msgf("Failed to get %s() accessTokenManagers items.", apiFunctionName)
+		l.Error().Msgf("%s Response Code: %s\nResponse Body: %s", apiFunctionName, response.Status, response.Body)
+		return nil, fmt.Errorf("failed to fetch %s resources via %s()", r.ResourceType(), apiFunctionName)
+	}
+
+	importBlocks := []connector.ImportBlock{}
+
+	l.Debug().Msgf("Generating Import Blocks for all %s resources...", r.ResourceType())
+
+	for _, accessTokenManager := range accessTokenManagersItems {
+		accessTokenManagerId, accessTokenManagerIdOk := accessTokenManager.GetIdOk()
+		accessTokenManagerName, accessTokenManagerNameOk := accessTokenManager.GetNameOk()
+
+		if accessTokenManagerIdOk && accessTokenManagerNameOk {
+			commentData := map[string]string{
+				"Resource Type":                            r.ResourceType(),
+				"OAuth Access Token Manager Resource ID":   *accessTokenManagerId,
+				"OAuth Access Token Manager Resource Name": *accessTokenManagerName,
+			}
+
+			importBlocks = append(importBlocks, connector.ImportBlock{
+				ResourceType:       r.ResourceType(),
+				ResourceName:       *accessTokenManagerName,
+				ResourceID:         *accessTokenManagerId,
+				CommentInformation: common.GenerateCommentInformation(commentData),
+			})
+		}
+	}
+
+	return &importBlocks, nil
+}
+
+func (r *PingFederateOAuthAccessTokenManagerResource) ResourceType() string {
+	return "pingfederate_oauth_access_token_manager"
+}

--- a/internal/connector/pingfederate/resources/pingfederate_oauth_access_token_manager_test.go
+++ b/internal/connector/pingfederate/resources/pingfederate_oauth_access_token_manager_test.go
@@ -1,0 +1,26 @@
+package resources_test
+
+import (
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingfederate/resources"
+	"github.com/pingidentity/pingctl/internal/testing/testutils"
+)
+
+func TestPingFederateOAuthAccessTokenManagerExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	PingFederateClientInfo := testutils.GetPingFederateClientInfo(t)
+	resource := resources.OAuthAccessTokenManager(PingFederateClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingfederate_oauth_access_token_manager",
+			ResourceName: "JSON Web Tokens",
+			ResourceID:   "jwt",
+		},
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
+}

--- a/internal/connector/pingfederate/resources/pingfederate_oauth_access_token_mapping.go
+++ b/internal/connector/pingfederate/resources/pingfederate_oauth_access_token_mapping.go
@@ -1,0 +1,84 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/common"
+	"github.com/pingidentity/pingctl/internal/logger"
+)
+
+// Verify that the resource satisfies the exportable resource interface
+var (
+	_ connector.ExportableResource = &PingFederateOAuthAccessTokenMappingResource{}
+)
+
+type PingFederateOAuthAccessTokenMappingResource struct {
+	clientInfo *connector.PingFederateClientInfo
+}
+
+// Utility method for creating a PingFederateOAuthAccessTokenMappingResource
+func OAuthAccessTokenMapping(clientInfo *connector.PingFederateClientInfo) *PingFederateOAuthAccessTokenMappingResource {
+	return &PingFederateOAuthAccessTokenMappingResource{
+		clientInfo: clientInfo,
+	}
+}
+
+func (r *PingFederateOAuthAccessTokenMappingResource) ExportAll() (*[]connector.ImportBlock, error) {
+	l := logger.Get()
+
+	l.Debug().Msgf("Fetching all %s resources...", r.ResourceType())
+
+	apiExecuteFunc := r.clientInfo.ApiClient.OauthAccessTokenMappingsAPI.GetMappings(r.clientInfo.Context).Execute
+	apiFunctionName := "GetMappings"
+
+	accessTokenMappings, response, err := apiExecuteFunc()
+
+	err = common.HandleClientResponse(response, err, apiFunctionName, r.ResourceType())
+	if err != nil {
+		return nil, err
+	}
+
+	if accessTokenMappings == nil {
+		l.Error().Msgf("Returned %s() accessTokenMappings is nil.", apiFunctionName)
+		l.Error().Msgf("%s Response Code: %s\nResponse Body: %s", apiFunctionName, response.Status, response.Body)
+		return nil, fmt.Errorf("failed to fetch %s resources via %s()", r.ResourceType(), apiFunctionName)
+	}
+
+	importBlocks := []connector.ImportBlock{}
+
+	l.Debug().Msgf("Generating Import Blocks for all %s resources...", r.ResourceType())
+
+	for _, accessTokenMapping := range accessTokenMappings {
+		accessTokenMappingId, accessTokenMappingIdOk := accessTokenMapping.GetIdOk()
+		accessTokenMappingContext, accessTokenMappingContextOk := accessTokenMapping.GetContextOk()
+		var (
+			accessTokenMappingContextType   *string
+			accessTokenMappingContextTypeOk bool
+		)
+		if accessTokenMappingContextOk {
+			accessTokenMappingContextType, accessTokenMappingContextTypeOk = accessTokenMappingContext.GetTypeOk()
+		}
+
+		if accessTokenMappingIdOk && accessTokenMappingContextOk && accessTokenMappingContextTypeOk {
+			commentData := map[string]string{
+				"Resource Type":                           r.ResourceType(),
+				"OAuth Access Token Mapping Resource ID":  *accessTokenMappingId,
+				"OAuth Access Token Mapping Context Type": *accessTokenMappingContextType,
+			}
+
+			importBlocks = append(importBlocks, connector.ImportBlock{
+				ResourceType:       r.ResourceType(),
+				ResourceName:       fmt.Sprintf("%s_%s", *accessTokenMappingId, *accessTokenMappingContextType),
+				ResourceID:         *accessTokenMappingId,
+				CommentInformation: common.GenerateCommentInformation(commentData),
+			})
+		}
+	}
+
+	return &importBlocks, nil
+}
+
+func (r *PingFederateOAuthAccessTokenMappingResource) ResourceType() string {
+	return "pingfederate_oauth_access_token_mapping"
+}

--- a/internal/connector/pingfederate/resources/pingfederate_oauth_access_token_mapping_test.go
+++ b/internal/connector/pingfederate/resources/pingfederate_oauth_access_token_mapping_test.go
@@ -1,0 +1,31 @@
+package resources_test
+
+import (
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingfederate/resources"
+	"github.com/pingidentity/pingctl/internal/testing/testutils"
+)
+
+func TestPingFederateOAuthAccessTokenMappingExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	PingFederateClientInfo := testutils.GetPingFederateClientInfo(t)
+	resource := resources.OAuthAccessTokenMapping(PingFederateClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingfederate_oauth_access_token_mapping",
+			ResourceName: "default|jwt_DEFAULT",
+			ResourceID:   "default|jwt",
+		},
+		{
+			ResourceType: "pingfederate_oauth_access_token_mapping",
+			ResourceName: "client_credentials|jwt_CLIENT_CREDENTIALS",
+			ResourceID:   "client_credentials|jwt",
+		},
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
+}

--- a/internal/connector/pingfederate/resources/pingfederate_oauth_ciba_server_policy_settings.go
+++ b/internal/connector/pingfederate/resources/pingfederate_oauth_ciba_server_policy_settings.go
@@ -1,0 +1,52 @@
+package resources
+
+import (
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/common"
+	"github.com/pingidentity/pingctl/internal/logger"
+)
+
+// Verify that the resource satisfies the exportable resource interface
+var (
+	_ connector.ExportableResource = &PingFederateOAuthCIBAServerPolicySettingsResource{}
+)
+
+type PingFederateOAuthCIBAServerPolicySettingsResource struct {
+	clientInfo *connector.PingFederateClientInfo
+}
+
+// Utility method for creating a PingFederateOAuthCIBAServerPolicySettingsResource
+func OAuthCIBAServerPolicySettings(clientInfo *connector.PingFederateClientInfo) *PingFederateOAuthCIBAServerPolicySettingsResource {
+	return &PingFederateOAuthCIBAServerPolicySettingsResource{
+		clientInfo: clientInfo,
+	}
+}
+
+func (r *PingFederateOAuthCIBAServerPolicySettingsResource) ExportAll() (*[]connector.ImportBlock, error) {
+	l := logger.Get()
+
+	importBlocks := []connector.ImportBlock{}
+
+	l.Debug().Msgf("Generating Import Blocks for all %s resources...", r.ResourceType())
+
+	oAuthCIBAServerPolicySettingsId := "oauth_ciba_server_policy_settings_singleton_id"
+	oAuthCIBAServerPolicySettingsName := "OAuth CIBA Server Policy Settings"
+
+	commentData := map[string]string{
+		"Resource Type": r.ResourceType(),
+		"Singleton ID":  common.SINGLETON_ID_COMMENT_DATA,
+	}
+
+	importBlocks = append(importBlocks, connector.ImportBlock{
+		ResourceType:       r.ResourceType(),
+		ResourceName:       oAuthCIBAServerPolicySettingsName,
+		ResourceID:         oAuthCIBAServerPolicySettingsId,
+		CommentInformation: common.GenerateCommentInformation(commentData),
+	})
+
+	return &importBlocks, nil
+}
+
+func (r *PingFederateOAuthCIBAServerPolicySettingsResource) ResourceType() string {
+	return "pingfederate_oauth_ciba_server_policy_settings"
+}

--- a/internal/connector/pingfederate/resources/pingfederate_oauth_ciba_server_policy_settings_test.go
+++ b/internal/connector/pingfederate/resources/pingfederate_oauth_ciba_server_policy_settings_test.go
@@ -1,0 +1,26 @@
+package resources_test
+
+import (
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingfederate/resources"
+	"github.com/pingidentity/pingctl/internal/testing/testutils"
+)
+
+func TestPingFederateOAuthCIBAServerPolicySettingsExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	PingFederateClientInfo := testutils.GetPingFederateClientInfo(t)
+	resource := resources.OAuthCIBAServerPolicySettings(PingFederateClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingfederate_oauth_ciba_server_policy_settings",
+			ResourceName: "OAuth CIBA Server Policy Settings",
+			ResourceID:   "oauth_ciba_server_policy_settings_singleton_id",
+		},
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
+}

--- a/internal/connector/pingfederate/resources/pingfederate_oauth_client.go
+++ b/internal/connector/pingfederate/resources/pingfederate_oauth_client.go
@@ -1,0 +1,84 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/common"
+	"github.com/pingidentity/pingctl/internal/logger"
+)
+
+// Verify that the resource satisfies the exportable resource interface
+var (
+	_ connector.ExportableResource = &PingFederateOAuthClientResource{}
+)
+
+type PingFederateOAuthClientResource struct {
+	clientInfo *connector.PingFederateClientInfo
+}
+
+// Utility method for creating a PingFederateOAuthClientResource
+func OAuthClient(clientInfo *connector.PingFederateClientInfo) *PingFederateOAuthClientResource {
+	return &PingFederateOAuthClientResource{
+		clientInfo: clientInfo,
+	}
+}
+
+func (r *PingFederateOAuthClientResource) ExportAll() (*[]connector.ImportBlock, error) {
+	l := logger.Get()
+
+	l.Debug().Msgf("Fetching all %s resources...", r.ResourceType())
+
+	apiExecuteFunc := r.clientInfo.ApiClient.OauthClientsAPI.GetOauthClients(r.clientInfo.Context).Execute
+	apiFunctionName := "GetOauthClients"
+
+	clients, response, err := apiExecuteFunc()
+
+	err = common.HandleClientResponse(response, err, apiFunctionName, r.ResourceType())
+	if err != nil {
+		return nil, err
+	}
+
+	if clients == nil {
+		l.Error().Msgf("Returned %s() clients is nil.", apiFunctionName)
+		l.Error().Msgf("%s Response Code: %s\nResponse Body: %s", apiFunctionName, response.Status, response.Body)
+		return nil, fmt.Errorf("failed to fetch %s resources via %s()", r.ResourceType(), apiFunctionName)
+	}
+
+	clientsItems, ok := clients.GetItemsOk()
+	if !ok {
+		l.Error().Msgf("Failed to get %s() clients items.", apiFunctionName)
+		l.Error().Msgf("%s Response Code: %s\nResponse Body: %s", apiFunctionName, response.Status, response.Body)
+		return nil, fmt.Errorf("failed to fetch %s resources via %s()", r.ResourceType(), apiFunctionName)
+	}
+
+	importBlocks := []connector.ImportBlock{}
+
+	l.Debug().Msgf("Generating Import Blocks for all %s resources...", r.ResourceType())
+
+	for _, client := range clientsItems {
+		clientId, clientIdOk := client.GetClientIdOk()
+		clientName, clientNameOk := client.GetNameOk()
+
+		if clientIdOk && clientNameOk {
+			commentData := map[string]string{
+				"Resource Type":              r.ResourceType(),
+				"OAuth Client Resource ID":   *clientId,
+				"OAuth Client Resource Name": *clientName,
+			}
+
+			importBlocks = append(importBlocks, connector.ImportBlock{
+				ResourceType:       r.ResourceType(),
+				ResourceName:       *clientName,
+				ResourceID:         *clientId,
+				CommentInformation: common.GenerateCommentInformation(commentData),
+			})
+		}
+	}
+
+	return &importBlocks, nil
+}
+
+func (r *PingFederateOAuthClientResource) ResourceType() string {
+	return "pingfederate_oauth_client"
+}

--- a/internal/connector/pingfederate/resources/pingfederate_oauth_client_test.go
+++ b/internal/connector/pingfederate/resources/pingfederate_oauth_client_test.go
@@ -1,0 +1,26 @@
+package resources_test
+
+import (
+	"testing"
+
+	"github.com/pingidentity/pingctl/internal/connector"
+	"github.com/pingidentity/pingctl/internal/connector/pingfederate/resources"
+	"github.com/pingidentity/pingctl/internal/testing/testutils"
+)
+
+func TestPingFederateOAuthClientExport(t *testing.T) {
+	// Get initialized apiClient and resource
+	PingFederateClientInfo := testutils.GetPingFederateClientInfo(t)
+	resource := resources.OAuthClient(PingFederateClientInfo)
+
+	// Defined the expected ImportBlocks for the resource
+	expectedImportBlocks := []connector.ImportBlock{
+		{
+			ResourceType: "pingfederate_oauth_client",
+			ResourceName: "test",
+			ResourceID:   "test",
+		},
+	}
+
+	testutils.ValidateImportBlocks(t, resource, &expectedImportBlocks)
+}


### PR DESCRIPTION
* Add PF resource export pingfederate_oauth_client
* Add PF resource export pingfederate_oauth_ciba_server_policy_settings
* Add PF resource export pingfederate_oauth_access_token_mapping
* Add PF resource export pingfederate_oauth_access_token_manager
* Add PF resource export pingfederate_notification_publishers_settings